### PR TITLE
fix: bad hydration because of markdown extensions- convert to <Option/> component

### DIFF
--- a/docs/2.0/actions.md
+++ b/docs/2.0/actions.md
@@ -164,7 +164,7 @@ end
 
 The available action responses are:
 
-:::option `reload`
+<Option name="`reload`">
 
 When you use `reload`, a full-page reload will be triggered.
 
@@ -181,8 +181,8 @@ def handle(**args)
 end
 ```
 
-:::
-:::option `redirect_to`
+</Option>
+<Option name="`redirect_to`">
 
 `redirect_to` will execute a redirect to a new path of your app. It accept `allow_other_host`, `status` and any other arguments.
 
@@ -274,17 +274,18 @@ class Update < Avo::BaseAction
   end
 end
 ```
+:::
 
 :::info `turbo_frame`
 Notice the `turbo_frame: "actions_show"` present on the redirect of `PreUpdate` action. That argument is essential to have a flawless redirect between the actions.
 :::
+</Option>
 
-
-:::option `turbo`
+<Option name="`turbo`">
 There are times when you don't want to perform the actions with Turbo. In such cases, turbo should be set to false.
-:::
+</Option>
 
-:::option `download`
+<Option name="`download`">
 
 `download` will start a file download to your specified `path` and `filename`.
 
@@ -292,7 +293,7 @@ There are times when you don't want to perform the actions with Turbo. In such c
 
 If you find another way, please let us know 😅.
 
-::: code-group
+:::code-group
 
 ```ruby{3,19} [app/avo/actions/download_file.rb]
 class DownloadFile < Avo::BaseAction
@@ -327,8 +328,9 @@ class ProjectResource < Avo::BaseResource
 end
 ```
 :::
+</Option>
 
-:::option `keep_modal_open`
+<Option name="`keep_modal_open`">
 
 There might be situations where you want to run an action and if it fails, respond back to the user with some feedback but still keep it open and the inputs filled in.
 
@@ -355,7 +357,7 @@ class KeepModalOpenAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
 ## Customization
 

--- a/docs/2.0/associations/belongs_to.md
+++ b/docs/2.0/associations/belongs_to.md
@@ -16,15 +16,15 @@ You will see three field types when you add a `BelongsTo` association to a model
 
 <!-- @include: ./../common/associations_searchable_option_common.md-->
 
-:::option `allow_via_detaching`
+<Option name="`allow_via_detaching`">
 Keeps the field enabled when visiting from the parent record.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
 <!-- @include: ./../common/associations_attach_scope_option_common.md-->
 
-:::option `polymorphic_as`
+<Option name="`polymorphic_as`">
 Sets the field as polymorphic with the key set on the model.
 
 #### Default
@@ -34,9 +34,9 @@ Sets the field as polymorphic with the key set on the model.
 #### Possible values
 
 A symbol, used on the `belongs_to` association with `polymorphic: true`.
-:::
+</Option>
 
-:::option `types`
+<Option name="`types`">
 Sets the types the field can morph to.
 
 #### Default
@@ -46,9 +46,9 @@ Sets the types the field can morph to.
 #### Possible values
 
 `[Post, Project, Team]`. Any array of model names.
-:::
+</Option>
 
-:::option `polymorphic_help`
+<Option name="`polymorphic_help`">
 Sets the help text for the polymorphic type dropdown. Useful when you need to specify to the user why and what they need to choose as polymorphic.
 
 #### Default
@@ -58,7 +58,7 @@ Sets the help text for the polymorphic type dropdown. Useful when you need to sp
 #### Possible values
 
 Any string.
-:::
+</Option>
 
 <!-- @include: ./../common/associations_use_resource_option_common.md-->
 

--- a/docs/2.0/authorization.md
+++ b/docs/2.0/authorization.md
@@ -54,37 +54,37 @@ These methods control whether the resource appears on the sidebar, if the view/e
 
 </Option>
 
-:::option `show?`
+<Option name="`show?`">
 
 When setting `show?` to `false`, the user will not see the show icon on the resource row and will not have access to the **Show** view of a resource.
 
-:::
+</Option>
 
-:::option `create?`
+<Option name="`create?`">
 
 The `create?` method will prevent the users from creating a resource. That will also apply to the `Create new {model}` button on the <Index />, the `Save` button on the `/new` page, and `Create new {model}` button on the association `Show` page.
 
-:::
+</Option>
 
-:::option `new?`
+<Option name="`new?`">
 
 The `new?` method will control whether the users can save the new resource. You can also access the `record` variable with the form values pre-filled.
 
-:::
+</Option>
 
-:::option `edit?`
+<Option name="`edit?`">
 
 `edit?` to `false` will hide the edit button on the resource row and prevent the user from seeing the edit view.
 
-:::
+</Option>
 
-:::option `update?`
+<Option name="`update?`">
 
 `update?` to `false` will prevent the user from updating a resource. You can also access the `record` variable with the form values pre-filled.
 
-:::
+</Option>
 
-::::option `destroy?`
+<Option name="`destroy?`">
 
 `destroy?` to `false` will prevent the user from destroying a resource and hiding the delete button.
 
@@ -92,21 +92,21 @@ The `new?` method will control whether the users can save the new resource. You 
 These are per-resource and general settings. If you want to control the authorization per individual file, please see the [granular settings](#attachments).
 :::
 
-::::
+</Option>
 
-:::option `act_on?`
+<Option name="`act_on?`">
 
 Controls whether the user can see the actions button on the <Index /> page.
 
-:::
+</Option>
 
 <img :src="('/assets/img/authorization/actions_button.jpg')" alt="Actions button" class="border mb-4" />
 
-:::option `reorder?`
+<Option name="`reorder?`">
 
 Controls whether the user can see the [records reordering](./records-reordering) buttons on the <Index /> page.
 
-:::
+</Option>
 ## Associations
 
 When using associations, you would like to set policies for `creating` new records on the association, allowing to `attach`, `detach`, `create` or `destroy` relevant records. Again, Avo makes this easy using a straightforward naming schema.
@@ -126,26 +126,26 @@ We'll have this example of a `Post` resource with many `Comment`s through the `h
 In the `Post` `has_many` `Comments` example, when you want to authorize `show_comments?` in `PostPolicy` you will have a `Comment` instance as the `record` variable, but when you try to authorize the `attach_comments?`, you won't have that `Comment` instance because you want to create one, but we expose the parent `Post` instance so you have more information about that authorization action that you're trying to make.
 :::
 
-:::option `attach_{association}?`
+<Option name="`attach_{association}?`">
 
 Controls whether the `Attach comment` button is visible. The `record` variable is the parent record (a `Post` instance in our scenario).
 
 <img :src="('/assets/img/authorization/attach.jpg')" class="border mb-4" />
 
-:::
-:::option `detach_{association}?`
+</Option>
+<Option name="`detach_{association}?`">
 
 Controls whether the **detach button is available** on the associated record row on the <Index /> view. The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
 <img :src="('/assets/img/authorization/detach.jpg')" class="border mb-4" />
 
-:::
-:::option `view_{association}?`
+</Option>
+<Option name="`view_{association}?`">
 
 Controls whether the whole association is being displayed on the parent record. The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
-:::
-::::option `show_{association}?`
+</Option>
+<Option name="`show_{association}?`">
 
 Controls whether the **view button is visible** on the associated record row on the <Index /> page. The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
@@ -163,8 +163,8 @@ When you use the `view_comments?` policy method you get the `Post` instance as t
 When you use `show_comments?` policy method, the `record` variable is each `Comment` instance and you control whether the view button is displayed on each individual row.
 :::
 
-::::
-::::option `edit_{association}?`
+</Option>
+<Option name="`edit_{association}?`">
 
 Controls whether the **edit button is visible** on the associated record row on the <Index /> page.The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
@@ -174,32 +174,32 @@ This **does not** control whether the user has access to that record's edit page
 
 <img :src="('/assets/img/authorization/edit.jpg')" class="border mb-4" />
 
-::::
-:::option `create_{association}?`
+</Option>
+<Option name="`create_{association}?`">
 
 Controls whether the `Create comment` button is visible. The `record` variable is the parent record (a `Post` instance in our scenario).
 
 <img :src="('/assets/img/authorization/create.jpg')" class="border mb-4" />
 
-:::
-:::option `destroy_{association}?`
+</Option>
+<Option name="`destroy_{association}?`">
 
 Controls whether the **delete button is visible** on the associated record row on the <Index /> page.The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
 <img :src="('/assets/img/authorization/destroy.jpg')" class="border mb-4" />
 
-:::
-:::option `act_on_{association}?`
+</Option>
+<Option name="`act_on_{association}?`">
 
 Controls whether the `Actions` dropdown is visible. The `record` variable is the parent record (a `Post` instance in our scenario).
 
 <img :src="('/assets/img/authorization/actions.jpg')" class="border mb-4" />
 
-:::
-:::option `reorder_{association}?`
+</Option>
+<Option name="`reorder_{association}?`">
 
 Controls whether the user can see the [records reordering](./records-reordering) buttons on the `has_many` <Index /> page.
-:::
+</Option>
 
 ## Removing duplication
 
@@ -301,17 +301,17 @@ Both the `record` and the `user` will be available for you to access.
 
 <img :src="('/assets/img/authorization/file_actions.png')" class="border mb-4 rounded" />
 
-:::option `upload_{FIELD_ID}?`
+<Option name="`upload_{FIELD_ID}?`">
 Controls whether the user can upload the attachment.
-:::
+</Option>
 
-:::option `download_{FIELD_ID}?`
+<Option name="`download_{FIELD_ID}?`">
 Controls whether the user can download the attachment.
-:::
+</Option>
 
-:::option `delete_{FIELD_ID}?`
+<Option name="`delete_{FIELD_ID}?`">
 Controls whether the user can destroy the attachment.
-:::
+</Option>
 
 :::info AUTHORIZE IN BULK
 If you want to allow or disallow these methods in bulk you can use a little meta-programming to assign all the same value.
@@ -327,32 +327,32 @@ end
 ```
 :::
 
-::::option `upload_attachments?`
+<Option name="`upload_attachments?`">
 
 :::warning DEPRECATED since 2.30.1
 This option was removed in **Avo 2.30.1** in favor of `upload_{FIELD_ID}?` method where `FIELD_ID` is the ID of the attachment field (ex: for `has_one_attached :photo` you need to declare the `upload_photo?` method).
 :::
 
 Controls whether the attachment upload input should be visible in the `File` and `Files` fields.
-::::
+</Option>
 
-::::option `download_attachments?`
+<Option name="`download_attachments?`">
 
 :::warning DEPRECATED since 2.30.1
 This option was removed in **Avo 2.30.1** in favor of `download_{FIELD_ID}?` method where `FIELD_ID` is the ID of the attachment field (ex: for `has_one_attached :photo` you need to declare the `download_photo?` method).
 :::
 
 Controls whether the attachment download button should be visible in the `File` and `Files` fields.
-::::
+</Option>
 
-::::option `delete_attachments?`
+<Option name="`delete_attachments?`">
 
 :::warning DEPRECATED since 2.30.1
 This option was removed in Avo 2.30.1 in favor of `delete_{FIELD_ID}?` method where `FIELD_ID` is the ID of the attachment field (ex: for `has_one_attached :photo` you need to declare the `delete_photo?` method).
 :::
 
 Controls whether the attachment delete button should be visible in the `File` and `Files` fields.
-::::
+</Option>
 
 ## Scopes
 
@@ -468,7 +468,7 @@ end
 
 Each authorization client must expose a few methods.
 
-:::option `authorize`
+<Option name="`authorize`">
 
 Receives the `user`, `record`, `action`, and optionally, the `policy_class` (you may want to use custom policy classes for some resources).
 
@@ -483,8 +483,8 @@ rescue Pundit::NotAuthorizedError => error
 end
 ```
 
-:::
-:::option `policy`
+</Option>
+<Option name="`policy`">
 
 Receives the `user` and `record` and returns the policy to use.
 
@@ -494,8 +494,8 @@ def policy(user, record)
 end
 ```
 
-:::
-:::option `policy!`
+</Option>
+<Option name="`policy!`">
 
 Receives the `user` and `record` and returns the policy to use. It will raise an error if no policy is found.
 
@@ -507,8 +507,8 @@ rescue Pundit::NotDefinedError => error
 end
 ```
 
-:::
-:::option `apply_policy`
+</Option>
+<Option name="`apply_policy`">
 
 Receives the `user`, `record`, and optionally, the policy class to use. It will apply a scope to a query.
 
@@ -528,7 +528,7 @@ rescue Pundit::NotDefinedError => error
   raise NoPolicyError.new error.message
 end
 ```
-:::
+</Option>
 
 ## Rolify integration
 

--- a/docs/2.0/common/associations_attach_scope_option_common.md
+++ b/docs/2.0/common/associations_attach_scope_option_common.md
@@ -1,4 +1,4 @@
-:::option `attach_scope`
+<Option name="`attach_scope`">
 Scope out the records the user sees on the Attach modal.
 
 #### Default
@@ -14,4 +14,4 @@ field :user,
 ```
 
 Pass in a block where you attach scopes to the `query` object. The block is executed in the [`AssociationScopeHost`](./../evaluation-hosts.html#associationscopehost), so follow the docs to see what variables you have access to.
-:::
+</Option>

--- a/docs/2.0/common/associations_description_option_common.md
+++ b/docs/2.0/common/associations_description_option_common.md
@@ -1,4 +1,4 @@
-:::option `description`
+<Option name="`description`">
 Changes the text displayed under the association name.
 
 ![](/assets/img/associations/description-option.jpg)
@@ -10,4 +10,4 @@ Changes the text displayed under the association name.
 #### Possible values
 
 Any string.
-:::
+</Option>

--- a/docs/2.0/common/associations_discreet_pagination_option_common.md
+++ b/docs/2.0/common/associations_discreet_pagination_option_common.md
@@ -1,4 +1,4 @@
-:::option `discreet_pagination`
+<Option name="`discreet_pagination`">
 Hides the pagination details when only there's only one page for that association.
 
 #### Default
@@ -8,4 +8,4 @@ Hides the pagination details when only there's only one page for that associatio
 #### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/2.0/common/associations_hide_search_input_option_common.md
+++ b/docs/2.0/common/associations_hide_search_input_option_common.md
@@ -1,4 +1,4 @@
-:::option `hide_search_input`
+<Option name="`hide_search_input`">
 Hides the search input displayed on the association table.
 
 #### Default
@@ -8,4 +8,4 @@ Hides the search input displayed on the association table.
 #### Possible values
 
 `true`, `false`.
-:::
+</Option>

--- a/docs/2.0/common/associations_link_to_child_resource_common.md
+++ b/docs/2.0/common/associations_link_to_child_resource_common.md
@@ -1,4 +1,4 @@
-:::option `link_to_child_resource`
+<Option name="`link_to_child_resource`">
 
 Sets which resource should be used in an STI scenario.
 
@@ -11,4 +11,4 @@ See more on this in the [STI section](./../associations#link-to-child-resource-w
 #### Possible values
 
 `true`, `false`.
-:::
+</Option>

--- a/docs/2.0/common/associations_scope_option_common.md
+++ b/docs/2.0/common/associations_scope_option_common.md
@@ -1,4 +1,4 @@
-:::option `scope`
+<Option name="`scope`">
 Scope out the records displayed in the table.
 
 #### Default
@@ -14,4 +14,4 @@ field :user,
 ```
 
 Pass in a block where you attach scopes to the `query` object. The block gets executed in the [`AssociationScopeHost`](./../evaluation-hosts.html#associationscopehost), so follow the docs to see what variables you have access to.
-:::
+</Option>

--- a/docs/2.0/common/associations_searchable_option_common.md
+++ b/docs/2.0/common/associations_searchable_option_common.md
@@ -1,4 +1,4 @@
-::::option `searchable`
+<Option name="`searchable`">
 
 <div class="space-x-2">
   <LicenseReq license="pro" />
@@ -35,4 +35,4 @@ end
 #### Possible values
 
 `true`, `false`
-::::
+</Option>

--- a/docs/2.0/common/associations_use_resource_option_common.md
+++ b/docs/2.0/common/associations_use_resource_option_common.md
@@ -1,4 +1,4 @@
-:::option `use_resource`
+<Option name="`use_resource`">
 Sets a different resource to be used when displaying (or redirecting to) the association table.
 
 #### Default
@@ -8,4 +8,4 @@ Sets a different resource to be used when displaying (or redirecting to) the ass
 #### Possible values
 
 `PostResource`, `PhotoCommentResource`, or any Avo resource class.
-:::
+</Option>

--- a/docs/2.0/common/date_date_time_common.md
+++ b/docs/2.0/common/date_date_time_common.md
@@ -1,4 +1,4 @@
-:::option `first_day_of_week`
+<Option name="`first_day_of_week`">
 Set which should be the first date of the week in the picker calendar. Flatpickr [documentation](https://flatpickr.js.org/localization/) on that. 1 is Monday, and 7 is Sunday.
 
 #### Default value
@@ -8,9 +8,9 @@ Set which should be the first date of the week in the picker calendar. Flatpickr
 #### Possible values
 
 `1`, `2`, `3`, `4`, `5`, `6`, and `7`
-:::
+</Option>
 
-:::option `disable_mobile`
+<Option name="`disable_mobile`">
 By default, flatpickr is [disabled on mobile](https://flatpickr.js.org/mobile-support/) because the mobile date pickers tend to give a better experience, but you can override that using `disable_mobile: true` (misleading to set it to `true`, I know. We're just forwarding the option). So that will override that behavior and display flatpickr on mobile devices too.
 
 #### Default value
@@ -20,4 +20,4 @@ By default, flatpickr is [disabled on mobile](https://flatpickr.js.org/mobile-su
 #### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/2.0/common/file_options_common.md
+++ b/docs/2.0/common/file_options_common.md
@@ -1,4 +1,4 @@
-:::option `accept`
+<Option name="`accept`">
 Instructs the input to accept only a particular file type for that input using the `accept` option.
 
 ```ruby
@@ -12,9 +12,9 @@ field :cover_video, as: :file, accept: "image/*"
 #### Possible values
 
 `image/*`, `audio/*`, `doc/*`, or any other types from [the spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).
-:::
+</Option>
 
-:::option `direct_upload`
+<Option name="`direct_upload`">
 <LicenseReq license="pro" />
 
 If you have large files and don't want to overload the server with uploads, you can use the `direct_upload` feature, which will upload the file directly to your cloud provider.
@@ -24,9 +24,9 @@ field :cover_video, as: :file, direct_upload: true
 ```
 
 <!-- @include: ./default_boolean_false.md -->
-:::
+</Option>
 
-:::option `display_filename`
+<Option name="`display_filename`">
 Option that specify if the file should have the caption present or not.
 
 ```ruby
@@ -40,4 +40,4 @@ field :cover_video, as: :file, display_filename: false
 #### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/2.0/common/link_to_resource_common.md
+++ b/docs/2.0/common/link_to_resource_common.md
@@ -1,3 +1,3 @@
-:::option `link_to_resource`
+<Option name="`link_to_resource`">
 Wraps the content into an anchor that links to the resource.
-:::
+</Option>

--- a/docs/2.0/controllers.md
+++ b/docs/2.0/controllers.md
@@ -24,7 +24,7 @@ In order to make your controllers more flexible, there are several overridable m
 ## Create methods
 For the `create` method, you can modify the `after_create_path`, the messages, and the actions both on success or failure.
 
-:::option `after_create_path`
+<Option name="`after_create_path`">
 Overriding this method, you can tell Avo what path to follow after a record was created with success.
 
 ```ruby
@@ -32,9 +32,9 @@ def after_create_path
   "/avo/resources/users"
 end
 ```
-:::
+</Option>
 
-:::option `create_success_action`
+<Option name="`create_success_action`">
 Override this method to create a custom response when a record was created with success.
 
 ```ruby
@@ -44,9 +44,9 @@ def create_success_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `create_fail_action`
+<Option name="`create_fail_action`">
 Override this method to create a custom response when a record failed to be created.
 
 ```ruby
@@ -57,9 +57,9 @@ def create_fail_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `create_success_message`
+<Option name="`create_success_message`">
 Override this method to change the message the user receives when a record was created with success.
 
 ```ruby
@@ -67,9 +67,9 @@ def create_success_message
   "#{@resource.name} #{t("avo.was_successfully_created")}."
 end
 ```
-:::
+</Option>
 
-:::option `create_fail_message`
+<Option name="`create_fail_message`">
 Override this method to change the message the user receives when a record failed to be created.
 
 ```ruby
@@ -77,12 +77,12 @@ def create_fail_message
   t "avo.you_missed_something_check_form"
 end
 ```
-:::
+</Option>
 
 ## Update methods
 For the `update` method, you can modify the `after_update_path`, the messages, and the actions both on success or failure.
 
-:::option `after_update_path`
+<Option name="`after_update_path`">
 Overriding this method, you can tell Avo what path to follow after a record was updated with success.
 
 ```ruby
@@ -90,9 +90,9 @@ def after_update_path
   "/avo/resources/users"
 end
 ```
-:::
+</Option>
 
-:::option `update_success_action`
+<Option name="`update_success_action`">
 Override this method to create a custom response when a record was updated with success.
 
 ```ruby
@@ -102,9 +102,9 @@ def update_success_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `update_fail_action`
+<Option name="`update_fail_action`">
 Override this method to create a custom response when a record failed to be updated.
 
 ```ruby
@@ -115,9 +115,9 @@ def update_fail_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `update_success_message`
+<Option name="`update_success_message`">
 Override this method to change the message the user receives when a record was updated with success.
 
 ```ruby
@@ -125,9 +125,9 @@ def update_success_message
   "#{@resource.name} #{t("avo.was_successfully_updated")}."
 end
 ```
-:::
+</Option>
 
-:::option `update_fail_message`
+<Option name="`update_fail_message`">
 Override this method to change the message the user receives when a record failed to be updated.
 
 ```ruby
@@ -135,9 +135,9 @@ def update_fail_message
   t "avo.you_missed_something_check_form"
 end
 ```
-:::
+</Option>
 
-:::option `save_model_action`
+<Option name="`save_model_action`">
 Override this method to change how a record is being saved.
 
 ```ruby
@@ -145,12 +145,12 @@ def save_model_action
   @model.save!
 end
 ```
-:::
+</Option>
 
 ## Destroy methods
 For the `destroy` method, you can modify the `after_destroy_path`, the messages, and the actions both on success or failure.
 
-:::option `after_destroy_path`
+<Option name="`after_destroy_path`">
 Overriding this method, you can tell Avo what path to follow after a record was destroyed with success.
 
 ```ruby
@@ -158,9 +158,9 @@ def after_update_path
   "/avo/resources/users"
 end
 ```
-:::
+</Option>
 
-:::option `destroy_success_action`
+<Option name="`destroy_success_action`">
 Override this method to create a custom response when a record was destroyed with success.
 
 ```ruby
@@ -170,9 +170,9 @@ def destroy_success_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `destroy_fail_action`
+<Option name="`destroy_fail_action`">
 Override this method to create a custom response when a record failed to be destroyed.
 
 ```ruby
@@ -182,9 +182,9 @@ def destroy_fail_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `destroy_success_message`
+<Option name="`destroy_success_message`">
 Override this method to change the message the user receives when a record was destroyed with success.
 
 ```ruby
@@ -192,9 +192,9 @@ def destroy_success_message
   t("avo.resource_destroyed", attachment_class: @attachment_class)
 end
 ```
-:::
+</Option>
 
-:::option `destroy_fail_message`
+<Option name="`destroy_fail_message`">
 Override this method to change the message the user receives when a record failed to be destroyed.
 
 ```ruby
@@ -202,9 +202,9 @@ def destroy_fail_message
   @errors.present? ? @errors.join(". ") : t("avo.failed")
 end
 ```
-:::
+</Option>
 
-:::option `destroy_model_action`
+<Option name="`destroy_model_action`">
 Override this method to change how a record is being destroyed.
 
 ```ruby
@@ -212,4 +212,4 @@ def destroy_model_action
   @model.destroy!
 end
 ```
-:::
+</Option>

--- a/docs/2.0/customizable-controls.md
+++ b/docs/2.0/customizable-controls.md
@@ -52,31 +52,31 @@ A control is an item that you can place in a designated area. They can be one of
 
 You may use the following controls:
 
-:::option `back_button`
+<Option name="`back_button`">
 Links to a previous page. The link is not a `history.back()` action. It's computed based on the parameters sent by Avo. That ensures the user has consistent hierarchical progress through the app.
 
 #### Supported options
 
 `label`, `title`, `style`, `color`, and `icon`.
-:::
+</Option>
 
-:::option `delete_button`
+<Option name="`delete_button`">
 Adds the appropriate destroy form. It will take into account your authorization policy rules.
 
 #### Supported options
 
 `label`, `title`, `style`, `color`, and `icon`.
-:::
+</Option>
 
-:::option `detach_button`
+<Option name="`detach_button`">
 Adds the appropriate detach form. It's visible only on the association (`has_one`) page. It will take into account your authorization policy rules.
 
 #### Supported options
 
 `label`, `title`, `style`, `color`, and `icon`.
-:::
+</Option>
 
-:::option `actions_list`
+<Option name="`actions_list`">
 A dropdown where the user can see and run all the actions assigned to that resource.
 
 #### Supported options
@@ -96,25 +96,25 @@ actions_list exclude: DisableAccount
 # Or
 actions_list exclude: [ExportSelection, PublishPost]
 ```
-:::
+</Option>
 
-:::option `edit_button`
+<Option name="`edit_button`">
 Links to the record edit page.
 
 #### Supported options
 
 `label`, `title`, `style`, `color`, and `icon`.
-:::
+</Option>
 
-:::option `link_to`
+<Option name="`link_to`">
 Renders a link to a path set by you.
 
 #### Supported options
 
 `title`, `style`, `color`, `icon`, `target`, `data`, and `class`.
-:::
+</Option>
 
-:::option `action`
+<Option name="`action`">
 Renders a button that triggers an action. You must provide it an [Action](./actions) class.
 
 #### Supported options
@@ -128,7 +128,7 @@ action DisableAccount
 action ExportSelection, style: :text
 action PublishPost, color: :fuchsia, icon: "heroicons/outline/eye"
 ```
-:::
+</Option>
 
 :::warning
 The way `show_controls` works is like a shortcut the the actions that you already declared on your resource, so you should also declare it on the resource as you normally would in order to have it here.
@@ -149,53 +149,53 @@ end
 
 ## Control Options
 
-:::option `title`
+<Option name="`title`">
 Sets the tooltip for that control.
 
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `style`
+<Option name="`style`">
 Sets the `style` attribute for the [`Avo::ButtonComponent`](https://github.com/avo-hq/avo/blob/main/app/components/avo/button_component.rb).
 
 #### Possible values
 
 `:primary`, `:outline`, `:text`
-:::
+</Option>
 
-:::option `color`
+<Option name="`color`">
 Sets the `color` attribute for the [`Avo::ButtonComponent`](https://github.com/avo-hq/avo/blob/main/app/components/avo/button_component.rb)
 
 #### Possible values
 
 Can be any color of [Tailwind's default color pallete](https://tailwindcss.com/docs/customizing-colors#default-color-palette) as a symbol.
-:::
+</Option>
 
-:::option `icon`
+<Option name="`icon`">
 Sets the icon for that button.
 
 #### Possible values
 
 Any [Heroicon](https://heroicons.com) you want. You must specify the style of the heroicon like so `heoricons/outline/academic-cap` or `heroicons/solid/adjustments`.
-:::
+</Option>
 
-:::option `target`
+<Option name="`target`">
 Sets the target for that control. So whatever you pass here will be passed to the control.
 
 #### Possible values
 
 `:_blank`, `:_top`, `:_self`
-:::
+</Option>
 
-:::option `class`
+<Option name="`class`">
 Sets the classes for that control.
 
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
 ## Conditionally hiding/showing actions
 

--- a/docs/2.0/customization.md
+++ b/docs/2.0/customization.md
@@ -110,10 +110,6 @@ Using `full_width_container: true` tells Avo to display all views full-width.
 
 ## Cache resources on the `Index` view
 
-<!-- :::info
-  Since version <Version version="2.30" /> `cache_resources_on_index_view` is disabled by default.
-::: -->
-
 Avo caches each resource row (or Grid item for Grid view) for performance reasons. You can disable that cache using the `cache_resources_on_index_view` configuration option. The cache key is using the record's `id` and `created_at` attributes and the resource file `md5`.
 
 :::info

--- a/docs/2.0/field-wrappers.md
+++ b/docs/2.0/field-wrappers.md
@@ -19,7 +19,7 @@ Each field displayed on the <Index /> view is wrapped in this component that reg
 
 You may use the component `Avo::Index::FieldWrapperComponent` or the helper `index_field_wrapper`.
 
-:::option `dash_if_blank`
+<Option name="`dash_if_blank`">
 This option renders a dash `—` if the content inside responds to true on the `blank?` method.
 In the example below, we'd like to show the field as a red checkmark even if the content is `nil`.
 
@@ -32,9 +32,9 @@ In the example below, we'd like to show the field as a red checkmark even if the
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `center_content`
+<Option name="`center_content`">
 Wraps the content in a container with `flex items-center justify-center` classes making everything centered horizontally and vertically.
 
 #### Default
@@ -46,9 +46,9 @@ Wraps the content in a container with `flex items-center justify-center` classes
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `flush`
+<Option name="`flush`">
 Removes the padding around the field allowing it to flow from edge to edge.
 
 #### Default
@@ -60,9 +60,9 @@ Removes the padding around the field allowing it to flow from edge to edge.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `field`
+<Option name="`field`">
 The instance of the field. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -70,9 +70,9 @@ The instance of the field. It's usually passed in with the `field_wrapper_args`.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `resource`
+<Option name="`resource`">
 The instance of the resource. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -80,7 +80,7 @@ The instance of the resource. It's usually passed in with the `field_wrapper_arg
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
 # Show & Edit field wrapper
 
@@ -113,7 +113,7 @@ This space is rarely used and it's there just to fill some horizontal space so t
 
 ## Options
 
-:::option `dash_if_blank`
+<Option name="`dash_if_blank`">
 This option renders a dash `—` if the content inside responds to true on the `blank?` method.
 In the example below, we'd like to show the field as a red checkmark even if the content is `nil`.
 
@@ -126,9 +126,9 @@ In the example below, we'd like to show the field as a red checkmark even if the
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `compact`
+<Option name="`compact`">
 This renders the field in a more compact way by removing the **Extra** area and decresing the width of the **Label** and **Content** areas.
 
 This is enabled on the fields displayed in actions.
@@ -142,9 +142,9 @@ This is enabled on the fields displayed in actions.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `data`
+<Option name="`data`">
 Pass in some data attributes. Perhaps you would like to attach a StimulusJS controller to this field.
 
 ```erb
@@ -152,9 +152,9 @@ Pass in some data attributes. Perhaps you would like to attach a StimulusJS cont
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `full_width`
+<Option name="`full_width`">
 This removes the **Extra** area and renders the **Value** area full width.
 
 This is used on fields that require a larger area to be displayed like [WYSIWYG editors](./fields/trix), [`KeyValue`](./fields/key_value), or [file fields](./fields/files).
@@ -168,9 +168,9 @@ This is used on fields that require a larger area to be displayed like [WYSIWYG 
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `form`
+<Option name="`form`">
 The instance of the form that is going to be populated. It's usually passed in with the `field_wrapper_args` on the <Edit /> view.
 
 ```erb
@@ -178,9 +178,9 @@ The instance of the form that is going to be populated. It's usually passed in w
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `field`
+<Option name="`field`">
 The instance of the field. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -188,9 +188,9 @@ The instance of the field. It's usually passed in with the `field_wrapper_args`.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `help`
+<Option name="`help`">
 The text that is going to be displayed below the actual field on the <Edit /> view.
 
 ```erb
@@ -198,9 +198,9 @@ The text that is going to be displayed below the actual field on the <Edit /> vi
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `label`
+<Option name="`label`">
 The text that is going to be displayed in the **Label** area. You might want to override it.
 
 ```erb
@@ -208,9 +208,9 @@ The text that is going to be displayed in the **Label** area. You might want to 
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `resource`
+<Option name="`resource`">
 The instance of the resource. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -218,9 +218,9 @@ The instance of the resource. It's usually passed in with the `field_wrapper_arg
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `stacked`
+<Option name="`stacked`">
 Display the field in a column layout with the label on top of the value
 
 ```erb
@@ -228,12 +228,12 @@ Display the field in a column layout with the label on top of the value
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
 ![](/assets/img/field-wrappers/stacked_field.jpg)
 
 
-:::option `style`
+<Option name="`style`">
 The you might want to pass some styles to the wrapper to change it's looks.
 
 ```erb
@@ -241,9 +241,9 @@ The you might want to pass some styles to the wrapper to change it's looks.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `view`
+<Option name="`view`">
 The view where the field is diplayed so it knows if it's a <Show /> or <Edit /> view. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -251,5 +251,5 @@ The view where the field is diplayed so it knows if it's a <Show /> or <Edit /> 
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 

--- a/docs/2.0/fields/area.md
+++ b/docs/2.0/fields/area.md
@@ -36,7 +36,7 @@ Or Multi-Polygons:
 
 ## Options
 
-:::option `geometry`
+<Option name="`geometry`">
 
 #### Default
 
@@ -46,8 +46,8 @@ Or Multi-Polygons:
 
 `:polygon` or `:multi_polygon`
 
-:::
-:::option `mapkick_options`
+</Option>
+<Option name="`mapkick_options`">
 
 For example:
 
@@ -63,8 +63,8 @@ mapkick_options: { style: 'mapbox://styles/mapbox/satellite-v9', controls: true 
 
 Accepts the options as [specified in the Mapkick-gem](https://github.com/ankane/mapkick#options).
 
-:::
-:::option `datapoint_options`
+</Option>
+<Option name="`datapoint_options`">
 
 Fore example:
 
@@ -82,7 +82,7 @@ datapoint_options: { label: 'Paris City Center',
 
 Besides the general options related to the map, the area-field also accepts [datapoint-options](https://github.com/ankane/mapkick#area-map).
 
-:::
+</Option>
 
 ## Options combined
 

--- a/docs/2.0/fields/badge.md
+++ b/docs/2.0/fields/badge.md
@@ -32,7 +32,7 @@ The `Badge` field is intended to be displayed only on **Index** and **Show** vie
 
 ## Options
 
-:::option `options`
+<Option name="`options`">
 
 The options should be a hash with the keys of one of the five available types (`info`, `success`, `warning`, `danger`, `neutral`) and the values matching your record's database values.
 
@@ -41,7 +41,7 @@ The options should be a hash with the keys of one of the five available types (`
 `{ info: :info, success: :success, danger: :danger, warning: :warning, neutral: :neutral }`
 
 Below is an example of how you can use two fields in that combination.
-:::
+</Option>
 
 ## Examples
 

--- a/docs/2.0/fields/boolean.md
+++ b/docs/2.0/fields/boolean.md
@@ -19,7 +19,7 @@ field :is_published,
 
 ## Options
 
-:::option `true_value`
+<Option name="`true_value`">
 
 What should count as true. You can use `1`, `yes`, or a different value.
 
@@ -27,12 +27,12 @@ What should count as true. You can use `1`, `yes`, or a different value.
 
 `[true, "true", "1"]`
 
-:::
-:::option `false_value`
+</Option>
+<Option name="`false_value`">
 
 What should count as false. You can use `0`, `no`, or a different value.
 
 #### Default value
 
 `[false, "false", "0"]`
-:::
+</Option>

--- a/docs/2.0/fields/boolean_group.md
+++ b/docs/2.0/fields/boolean_group.md
@@ -17,7 +17,7 @@ field :roles, as: :boolean_group, name: 'User roles', options: { admin: 'Adminis
 
 ## Options
 
-:::option `options`
+<Option name="`options`">
 `options` should be a `Hash` with the keys to one of the four available types (`info`, `success`, `warning`, `danger`) and the values matching your record's database values.
 
 #### Default value
@@ -30,7 +30,7 @@ field :roles, as: :boolean_group, name: 'User roles', options: { admin: 'Adminis
   warning: :warning
 }
 ```
-:::
+</Option>
 
 ## Example DB payload
 

--- a/docs/2.0/fields/code.md
+++ b/docs/2.0/fields/code.md
@@ -15,7 +15,7 @@ field :custom_css, as: :code, theme: 'dracula', language: 'css'
 
 ## Options
 
-:::option `theme`
+<Option name="`theme`">
 
 Customize the color theme.
 
@@ -28,9 +28,9 @@ Customize the color theme.
 `material-darker`, `eclipse`, or `dracula`
 
 Preview the themes here: [codemirror-themes](https://codemirror.net/demo/theme.html).
-:::
+</Option>
 
-:::option `language`
+<Option name="`language`">
 Customize the syntax highlighting using the language method.
 
 #### Default value
@@ -40,9 +40,9 @@ Customize the syntax highlighting using the language method.
 #### Possible values
 
 `css`, `dockerfile`, `htmlmixed`, `javascript`, `markdown`, `nginx`, `php`, `ruby`, `sass`, `shell`, `sql`, `vue` or `xml`.
-:::
+</Option>
 
-:::option `height`
+<Option name="`height`">
 Customize the height of the editor.
 
 #### Default value
@@ -52,9 +52,9 @@ Customize the height of the editor.
 #### Possible values
 
 `auto`, or any value in pixels (eg `height: 250px`).
-:::
+</Option>
 
-:::option `tab_size`
+<Option name="`tab_size`">
 Customize the tab_size of the editor.
 
 #### Default value
@@ -64,9 +64,9 @@ Customize the tab_size of the editor.
 #### Possible values
 
 Any integer value.
-:::
+</Option>
 
-:::option `indent_with_tabs`
+<Option name="`indent_with_tabs`">
 Customize the type of indentation.
 
 #### Default value
@@ -76,9 +76,9 @@ Customize the type of indentation.
 #### Possible values
 
 `true` or `false`
-:::
+</Option>
 
-:::option `line_wrapping`
+<Option name="`line_wrapping`">
 Customize whether the editor should apply line wrapping.
 
 #### Default value
@@ -88,4 +88,4 @@ Customize whether the editor should apply line wrapping.
 #### Possible values
 
 `true` or `false`
-:::
+</Option>

--- a/docs/2.0/fields/country.md
+++ b/docs/2.0/fields/country.md
@@ -22,7 +22,7 @@ field :country, as: :country, display_code: true
 
 ## Options
 
-:::option `display_code`
+<Option name="`display_code`">
 
 You can easily choose to display the `code` of the country on **Index** and **Show** views by declaring `display_code` to `true`.
 
@@ -33,4 +33,4 @@ You can easily choose to display the `code` of the country on **Index** and **Sh
 ### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/2.0/fields/date.md
+++ b/docs/2.0/fields/date.md
@@ -18,7 +18,7 @@ field :birthday,
 
 ## Options
 
-:::option `format`
+<Option name="`format`">
 Format the date shown to the user on the `Index` and `Show` views.
 
 #### Default
@@ -28,8 +28,8 @@ Format the date shown to the user on the `Index` and `Show` views.
 #### Possible values
 
 Use [`luxon`](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) formatting tokens.
-:::
-:::option `picker_format`
+</Option>
+<Option name="`picker_format`">
 Format the date shown to the user on the `Edit` and `New` views.
 
 #### Default
@@ -39,9 +39,9 @@ Format the date shown to the user on the `Edit` and `New` views.
 #### Possible values
 
 Use [`flatpickr`](https://flatpickr.js.org/formatting) formatting tokens.
-:::
+</Option>
 
-:::option `picker_options`;
+<Option name="`picker_options`;">
 Passes the options here to [flatpickr](https://flatpickr.js.org/).
 
 #### Default
@@ -56,5 +56,5 @@ Use [`flatpickr`](https://flatpickr.js.org/options) options.
 These options may override other options like `picker_options`.
 :::
 
-::::
+</Option>
 <!-- @include: ./../common/date_date_time_common.md-->

--- a/docs/2.0/fields/date_time.md
+++ b/docs/2.0/fields/date_time.md
@@ -21,7 +21,7 @@ field :joined_at,
 
 ## Options
 
-:::option `format`
+<Option name="`format`">
 
 Format the date shown to the user on the `Index` and `Show` views.
 
@@ -32,8 +32,8 @@ Format the date shown to the user on the `Index` and `Show` views.
 #### Possible values
 
 Use [`luxon`](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) formatting tokens.
-:::
-:::option `picker_format`
+</Option>
+<Option name="`picker_format`">
 Format the date shown to the user on the `Edit` and `New` views.
 
 #### Default
@@ -43,13 +43,13 @@ Format the date shown to the user on the `Edit` and `New` views.
 #### Possible values
 
 Use [`flatpickr`](https://flatpickr.js.org/formatting) formatting tokens.
-:::
-:::option `time_24hr`
+</Option>
+<Option name="`time_24hr`">
 Displays time picker in 24-hour mode or AM/PM selection.
 
 <!-- @include: ./../common/default_boolean_false.md -->
-:::
-:::option `timezone`
+</Option>
+<Option name="`timezone`">
 Select in which timezone the values should be cast.
 
 #### Default
@@ -65,9 +65,9 @@ field :started_at, as: :date_time, timezone: "EET"
 # Or
 field :started_at, as: :date_time, timezone: -> { record.timezone }
 ```
-:::
+</Option>
 
-:::option `picker_options`
+<Option name="`picker_options`">
 Passes the options here to [flatpickr](https://flatpickr.js.org/).
 
 #### Default
@@ -77,7 +77,7 @@ Passes the options here to [flatpickr](https://flatpickr.js.org/).
 #### Possible values
 
 Use [`flatpickr`](https://flatpickr.js.org/options) options.
-:::
+</Option>
 
 :::warning
 These options may override other options like `time_24hr`.

--- a/docs/2.0/fields/external_image.md
+++ b/docs/2.0/fields/external_image.md
@@ -15,7 +15,7 @@ field :logo, as: :external_image
 
 ## Options
 
-:::option `width`
+<Option name="`width`">
 
 #### Default value
 
@@ -24,9 +24,9 @@ field :logo, as: :external_image
 #### Possible values
 
 Use any number to size the image.
-:::
+</Option>
 
-:::option `height`
+<Option name="`height`">
 #### Default value
 
 `40`
@@ -34,9 +34,9 @@ Use any number to size the image.
 #### Possible values
 
 Use any number to size the image.
-:::
+</Option>
 
-:::option `radius`
+<Option name="`radius`">
 #### Default value
 
 `0`
@@ -44,7 +44,7 @@ Use any number to size the image.
 #### Possible values
 
 Use any number to set the radius value.
-:::
+</Option>
 
 <!-- @include: ./../common/link_to_resource_common.md-->
 

--- a/docs/2.0/fields/files.md
+++ b/docs/2.0/fields/files.md
@@ -18,7 +18,7 @@ field :documents, as: :files
 
 <!-- @include: ./../common/file_other_common.md-->
 
-:::option `view_type`
+<Option name="`view_type`">
 ![](/assets/img/files_view_types.gif)
 
 Set the default `view_type`.
@@ -30,9 +30,9 @@ Set the default `view_type`.
 #### Possible values
 
 `grid`, `list`
-:::
+</Option>
 
-:::option `hide_view_type_switcher`
+<Option name="`hide_view_type_switcher`">
 Option to hide the view type switcher component.
 
 #### Default
@@ -42,4 +42,4 @@ Option to hide the view type switcher component.
 #### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/2.0/fields/gravatar.md
+++ b/docs/2.0/fields/gravatar.md
@@ -16,15 +16,15 @@ field :email,
 ```
 
 ## Options
-:::option `rounded`
+<Option name="`rounded`">
 Choose whether the rendered avatar should be rounded or not on the `Index` view.
 
 On `Show`, the image is always a `square,` and the size is `responsive`.
 
 <!-- @include: ./../common/default_boolean_true.md -->
-:::
+</Option>
 
-:::option `size`
+<Option name="`size`">
 Set the size of the avatar.
 
 #### Default
@@ -34,9 +34,9 @@ Set the size of the avatar.
 #### Possible values
 
 Any number in pixels. Remember that the size will influence the `Index` table row height.
-:::
+</Option>
 
-:::option `default`
+<Option name="`default`">
 Set the default image if the email address was not found in Gravatar's database.
 
 #### Default
@@ -46,7 +46,7 @@ Set the default image if the email address was not found in Gravatar's database.
 #### Possible values
 
 Any number in pixels. Remember that the size will influence the `Index` table row height.
-:::
+</Option>
 
 <!-- @include: ./../common/link_to_resource_common.md-->
 

--- a/docs/2.0/fields/heading.md
+++ b/docs/2.0/fields/heading.md
@@ -17,7 +17,7 @@ The `Heading` field displays a header that acts as a separation layer between di
 
 ## Options
 
-:::option `as_html`
+<Option name="`as_html`">
 The `as_html` option will render it as HTML.
 
 ```ruby
@@ -25,5 +25,5 @@ heading '<div class="underline text-gray-800 uppercase">Address fields</,div>', 
 ```
 
 <!-- @include: ./../common/default_boolean_false.md -->
-:::
+</Option>
 

--- a/docs/2.0/fields/key_value.md
+++ b/docs/2.0/fields/key_value.md
@@ -15,7 +15,7 @@ field :meta, as: :key_value
 
 ## Options
 
-:::option `key_label`
+<Option name="`key_label`">
 Customize the label for the key header.
 
 #### Default
@@ -25,9 +25,9 @@ Customize the label for the key header.
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `value_label`
+<Option name="`value_label`">
 Customize the label for the value header.
 
 #### Default
@@ -37,9 +37,9 @@ Customize the label for the value header.
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `action_text`
+<Option name="`action_text`">
 Customize the label for the add row button tooltip.
 
 #### Default
@@ -49,9 +49,9 @@ Customize the label for the add row button tooltip.
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `delete_text`
+<Option name="`delete_text`">
 Customize the label for the delete row button tooltip.
 
 #### Default
@@ -61,25 +61,25 @@ Customize the label for the delete row button tooltip.
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `disable_editing_keys`
+<Option name="`disable_editing_keys`">
 Toggle on/off the ability to edit the keys for that field. Turning this off will allow the user to customize only the value fields.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `disable_adding_rows`
+<Option name="`disable_adding_rows`">
 Toggle on/off the ability to add new rows.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `disable_deleting_rows`
+<Option name="`disable_deleting_rows`">
 Toggle on/off the ability to delete rows from that field. Turning this on will prevent the user from deleting existing rows.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
 ## Customizing the labels
 

--- a/docs/2.0/fields/location.md
+++ b/docs/2.0/fields/location.md
@@ -29,7 +29,7 @@ On the <Show /> view you'll get in interactive map and on the edit you'll get on
 
 ## Options
 
-:::option `stored_as`
+<Option name="`stored_as`">
 
 It's customary to have the coordinates in two distinct database columns, one named `latitude` and another `longitude`.
 
@@ -53,7 +53,8 @@ This will also render the <Edit /> view with two separate fields to edit the coo
 
 <img :src="('/assets/img/fields/location-edit.png')" alt="Location field" class="border mb-4" />
 
-:::option `zoom`
+</Option>
+<Option name="`zoom`">
 
 Changes the zoom level for the map with higher numbers being zoomed in and showing a smaller area on the map.
 
@@ -68,4 +69,4 @@ Any number between 0 (the most zoomed out) to 22 (the most zoomed in).
 ```ruby
 field :coordinates, as: :location, zoom: 5
 ```
-
+</Option>

--- a/docs/2.0/fields/markdown.md
+++ b/docs/2.0/fields/markdown.md
@@ -19,14 +19,14 @@ field :description, as: :markdown
 
 ## Options
 
-:::option `always_show`
+<Option name="`always_show`">
 
 By default, the content of the `Markdown` field is not visible on the `Show` view, instead, it's hidden under a `Show Content` link that, when clicked, displays the content. You can set Markdown to always display the content by setting `always_show` to `true`.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `height`
+<Option name="`height`">
 Sets the value of the editor
 
 #### Default
@@ -37,9 +37,9 @@ Sets the value of the editor
 #### Possible values
 
 `auto` or any number in pixels.
-:::
+</Option>
 
-:::option `spell_checker`
+<Option name="`spell_checker`">
 Toggles the editor's spell checker option.
 
 ```ruby
@@ -47,6 +47,6 @@ field :description, as: :markdown, spell_checker: true
 ```
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
 ## Enable spell checker

--- a/docs/2.0/fields/number.md
+++ b/docs/2.0/fields/number.md
@@ -13,7 +13,7 @@ field :age, as: :number
 
 ## Options
 
-:::option `min`
+<Option name="`min`">
 Set the `min` attribute.
 
 #### Default
@@ -23,9 +23,9 @@ Set the `min` attribute.
 #### Possible values
 
 Any number.
-:::
+</Option>
 
-:::option `max`
+<Option name="`max`">
 Set the `max` attribute.
 
 #### Default
@@ -35,9 +35,9 @@ Set the `max` attribute.
 #### Possible values
 
 Any number.
-:::
+</Option>
 
-:::option `step`
+<Option name="`step`">
 Set the `step` attribute.
 
 #### Default
@@ -47,7 +47,7 @@ Set the `step` attribute.
 #### Possible values
 
 Any number.
-:::
+</Option>
 
 ## Examples
 

--- a/docs/2.0/fields/progress_bar.md
+++ b/docs/2.0/fields/progress_bar.md
@@ -14,7 +14,7 @@ field :progress, as: :progress_bar
 
 ## Options
 
-:::option `max`
+<Option name="`max`">
 Sets the maximum value of the progress bar.
 
 #### Default
@@ -24,9 +24,9 @@ Sets the maximum value of the progress bar.
 #### Possible values
 
 Any number.
-:::
+</Option>
 
-:::option `step`
+<Option name="`step`">
 Sets the step in which the user can move the slider on the `Edit` and `New` views.
 
 #### Default
@@ -36,15 +36,15 @@ Sets the step in which the user can move the slider on the `Edit` and `New` view
 #### Possible values
 
 Any number.
-:::
+</Option>
 
-:::option `display_value`
+<Option name="`display_value`">
 Choose if the value is displayed on the `Edit` and `New` views above the slider.
 
 <!-- @include: ./../common/default_boolean_true.md-->
-:::
+</Option>
 
-:::option `value_suffix`
+<Option name="`value_suffix`">
 Set a string value to be displayed after the value above the progress bar.
 
 #### Default
@@ -54,7 +54,7 @@ Set a string value to be displayed after the value above the progress bar.
 #### Possible values
 
 `%` or any other string.
-:::
+</Option>
 
 ## Examples
 

--- a/docs/2.0/fields/select.md
+++ b/docs/2.0/fields/select.md
@@ -13,7 +13,7 @@ field :type, as: :select, options: { 'Large container': :large, 'Medium containe
 
 ## Options
 
-:::option `options`
+<Option name="`options`">
 A `Hash` representing the options that should be displayed in the select. The keys represent the labels, and the values represent the value stored in the database.
 
 The options get cast as `ActiveSupport::HashWithIndifferentAccess` objects if they are a `Hash`.
@@ -25,9 +25,9 @@ The options get cast as `ActiveSupport::HashWithIndifferentAccess` objects if th
 #### Possible values
 
 `{ 'Large container': :large, 'Medium container': :medium, 'Tiny container': :tiny }` or any other `Hash`.
-:::
+</Option>
 
-:::option `enum`
+<Option name="`enum`">
 Set the select options as an Active Record [enum](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html). You may use `options` or `enum`, not both.
 
 ```ruby{3,10}
@@ -53,9 +53,9 @@ end
 #### Possible values
 
 `Post::statuses` or any other `enum` stored on a model.
-:::
+</Option>
 
-:::option `display_value`
+<Option name="`display_value`">
 You may want to display the values from the database and not the labels of the options. You may change that by setting `display_value` to `true`.
 
 ```ruby{5}
@@ -68,9 +68,9 @@ end
 ```
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `include_blank`
+<Option name="`include_blank`">
 ## Include blank
 
 The `Select` field also has the `include_blank` option. That can have three values.
@@ -97,7 +97,7 @@ end
 #### Possible values
 
 `nil`, `true`, `false`, or a string to be used as the first option.
-:::
+</Option>
 
 ## Computed options
 

--- a/docs/2.0/fields/status.md
+++ b/docs/2.0/fields/status.md
@@ -20,7 +20,7 @@ field :progress,
 
 ## Options
 
-:::option `failed_when`
+<Option name="`failed_when`">
 Set the values for when the status is `failed`.
 
 #### Default value
@@ -30,9 +30,9 @@ Set the values for when the status is `failed`.
 #### Possible values
 
 `[:closed, :rejected, :failed]` or an array with strings or symbols that indicate the `failed` state.
-:::
+</Option>
 
-:::option `loading_when`
+<Option name="`loading_when`">
 Set the values for when the status is `loading`.
 
 #### Default value
@@ -42,6 +42,6 @@ Set the values for when the status is `loading`.
 #### Possible values
 
 `[:loading, :running, :waiting, "in progress"]` or an array with strings or symbols that indicate the `loading` state.
-:::
+</Option>
 
 

--- a/docs/2.0/fields/tags.md
+++ b/docs/2.0/fields/tags.md
@@ -16,7 +16,7 @@ field :skills, as: :tags
 
 ## Options
 
-:::option `suggestions`
+<Option name="`suggestions`">
 
 You can give suggestions to your users to pick from which will be displayed to the user as a dropdown under the field.
 
@@ -72,9 +72,9 @@ class Post < ApplicationRecord
 end
 ```
 
-:::
+</Option>
 
-:::option `dissallowed`
+<Option name="`dissallowed`">
 The `disallowed` param works similarly to `suggestions`. Use it to prevent the user from adding specific values.
 
 ```ruby{3}
@@ -92,9 +92,9 @@ field :skills,
 #### Possible values
 
 An array of strings representing the value that can't be stored in the database.
-:::
+</Option>
 
-:::option `enforce_suggestions`
+<Option name="`enforce_suggestions`">
 Set whether the field should accept other values outside the suggested ones. If set to `true` the user won't be able to add anything else than what you posted in the `suggestions` option.
 
 ```ruby{4}
@@ -107,9 +107,9 @@ field :skills,
 <img :src="('/assets/img/fields/tags-field/enforce_suggestions.gif')" alt="Avo tags field" class="border mb-4" />
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `suggestions_max_items`
+<Option name="`suggestions_max_items`">
 Set of suggestions that can be displayed at once. The excessive items will be hidden and the user will have to narrow down the query to see them.
 
 ```ruby{4}
@@ -128,9 +128,9 @@ field :skills,
 #### Possible values
 
 Integers
-:::
+</Option>
 
-:::option `close_on_select`
+<Option name="`close_on_select`">
 Set whether the `suggestions` dropdown should close after the user makes a selection.
 
 ```ruby{4}
@@ -143,9 +143,9 @@ field :items,
 <img :src="('/assets/img/fields/tags-field/close_on_select.gif')" alt="Avo tags field" class="border mb-4" />
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `acts_as_taggable_on`
+<Option name="`acts_as_taggable_on`">
 Set the field the `acts_as_taggable_on` is set.
 
 #### Default
@@ -155,9 +155,9 @@ Set the field the `acts_as_taggable_on` is set.
 #### Possible values
 
 Any string or symbol you have configured on your corresponding model.
-:::
+</Option>
 
-:::option `disallowed`
+<Option name="`disallowed`">
 #### Default
 
 `false`
@@ -165,9 +165,9 @@ Any string or symbol you have configured on your corresponding model.
 #### Possible values
 
 `true`, `false`
-:::
+</Option>
 
-:::option `delimiters`
+<Option name="`delimiters`">
 
 Set the characters that will cut off the content into tags when the user inputs the tags.
 
@@ -189,10 +189,10 @@ field :skills,
 
 Valid values are comma `,` and space ` `.
 
-:::
+</Option>
 
 
-:::option `mode`
+<Option name="`mode`">
 
 By default, the tags field produces an array of items (ex: categories for posts), but in some scenarios you might want it to produce a single value (ex: dynamically search for users and select just one). Use `mode: :select` to make the field produce a single value as opposed to an array of values.
 
@@ -212,7 +212,7 @@ Valid values are `nil` for array values and `select` for a single value.
 
 ![](/assets/img/fields/tags-field/mode-select.gif)
 
-:::
+</Option>
 
 <Option name="`fetch_values_from`">
 
@@ -272,6 +272,7 @@ if defined? ::Avo
   end
 end
 ```
+:::
 
 :::info
 When using the `fetch_labels_from` pattern, on the <Show /> and <Index /> views you will see the `id` of those options instead of the label.
@@ -282,7 +283,7 @@ To mitigate that use the `fetch_labels` option.
 
 </Option>
 
-:::option `fetch_labels`
+<Option name="`fetch_labels`">
 The `fetch_labels` option allows you to pass an array of custom strings to be displayed on the tags field. This option is useful when Avo is displaying a bunch of IDs and you want to show some custom label from that ID's record.
 
 ```ruby{4-6}
@@ -305,7 +306,7 @@ Avo's default behavior on tags
 #### Possible values
 
 Array of strings
-:::
+</Option>
 
 ## PostgreSQL array fields
 

--- a/docs/2.0/fields/text.md
+++ b/docs/2.0/fields/text.md
@@ -12,7 +12,7 @@ field :title, as: :text
 ```
 ## Options
 
-:::option `as_html`
+<Option name="`as_html`">
 Displays the value as HTML on the `Index` and `Show` views. Useful when you need to link to another record.
 
 ```ruby
@@ -22,10 +22,10 @@ end
 ```
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
 
-:::option `protocol`
+<Option name="`protocol`">
 Render the value with a protocol prefix on the `Index` and `Show` views. So, for example, you can make a text field a `mailto` link very quickly.
 
 ```ruby{3}
@@ -43,7 +43,7 @@ field :email,
 #### Possible values
 
 `mailto`, `tel`, or any other string value you need to pass to it.
-:::
+</Option>
 
 <!-- @include: ./../common/link_to_resource_common.md-->
 

--- a/docs/2.0/fields/textarea.md
+++ b/docs/2.0/fields/textarea.md
@@ -14,7 +14,7 @@ field :body, as: :textarea
 ## Options
 
 
-:::option `rows`
+<Option name="`rows`">
 Set the number of rows visible in the `Edit` and `New` views.
 
 ```ruby
@@ -28,4 +28,4 @@ field :body, as: :textarea, rows: 5
 #### Possible values
 
 Any integer.
-:::
+</Option>

--- a/docs/2.0/fields/time.md
+++ b/docs/2.0/fields/time.md
@@ -22,7 +22,7 @@ field :starting_at,
 ```
 
 
-:::option `format`
+<Option name="`format`">
 
 Format the date shown to the user on the `Index` and `Show` views.
 
@@ -33,9 +33,9 @@ Format the date shown to the user on the `Index` and `Show` views.
 #### Possible values
 
 Use [`luxon`](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) formatting tokens.
-:::
+</Option>
 
-:::option `picker_format`
+<Option name="`picker_format`">
 Format the date shown to the user on the `Edit` and `New` views.
 
 #### Default
@@ -45,9 +45,9 @@ Format the date shown to the user on the `Edit` and `New` views.
 #### Possible values
 
 Use [`flatpickr`](https://flatpickr.js.org/formatting) formatting tokens.
-:::
+</Option>
 
-:::option `picker_options`;
+<Option name="`picker_options`;">
 Passes the options here to [flatpickr](https://flatpickr.js.org/).
 
 #### Default
@@ -62,4 +62,4 @@ Use [`flatpickr`](https://flatpickr.js.org/options) options.
 These options may override other options like `picker_options`.
 :::
 
-::::
+</Option>

--- a/docs/2.0/fields/trix.md
+++ b/docs/2.0/fields/trix.md
@@ -18,37 +18,37 @@ Trix field is hidden from the `Index` view.
 
 ## Options
 
-:::option `always_show`
+<Option name="`always_show`">
 By default, the content of the `Trix` field is not visible on the `Show` view; instead, it's hidden under a `Show Content` link that, when clicked, displays the content. You can set Markdown to display the content by setting `always_show` to `true`.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `attachments_disabled`
+<Option name="`attachments_disabled`">
 Hides the attachments button from the Trix toolbar.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `hide_attachment_filename`
+<Option name="`hide_attachment_filename`">
 Hides the attachment's name from the upload output in the field value.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `hide_attachment_filesize`
+<Option name="`hide_attachment_filesize`">
 Hides the attachment size from the upload output in the field value.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `hide_attachment_url`
+<Option name="`hide_attachment_url`">
 Hides the attachment URL from the upload output in the field value.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `attachment_key`
+<Option name="`attachment_key`">
 Enables file attachments.
 
 #### Default
@@ -58,7 +58,7 @@ Enables file attachments.
 #### Possible values
 
 `nil`, or a symbol representing the `has_many_attachments` key on the model.
-:::
+</Option>
 
 
 ## File attachments

--- a/docs/2.0/filters.md
+++ b/docs/2.0/filters.md
@@ -648,7 +648,7 @@ You may want to redirect users to filtered states of the <Index /> view from oth
 
 ### Rails helpers
 
-:::option `decode_filter_params`
+<Option name="`decode_filter_params`">
 
 Decodes the `filters` param. This Rails helper can be used anywhere in a view or off the `view_context`.
 
@@ -670,9 +670,9 @@ class DummyAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
-:::option `encode_filter_params`
+<Option name="`encode_filter_params`">
 
 Encodes a `filters` object into a serialized state that Avo understands. This Rails helper can be used anywhere in a view or off the `view_context`.
 
@@ -695,11 +695,11 @@ class DummyAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
 ### Standalone helpers
 
-:::option `Avo::Filters::BaseFilter.decode_filters`
+<Option name="`Avo::Filters::BaseFilter.decode_filters`">
 
 Decodes the `filters` param. This standalone method can be used anywhere.
 
@@ -716,9 +716,9 @@ class DummyAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
-:::option `Avo::Filters::BaseFilter.encode_filters`
+<Option name="`Avo::Filters::BaseFilter.encode_filters`">
 
 Encodes a `filters` object into a serialized state that Avo understands. This standalone method can be used anywhere.
 
@@ -735,7 +735,7 @@ class DummyAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
 ## Persistent filters
 

--- a/docs/2.0/map-view.md
+++ b/docs/2.0/map-view.md
@@ -36,21 +36,21 @@ class CityResource < Avo::BaseResource
 end
 ```
 
-:::option `mapkick_options`
+<Option name="`mapkick_options`">
 The options you pass here are forwarded to the [`mapkick` gem](https://github.com/ankane/mapkick).
-:::
+</Option>
 
-:::option `record_marker`
+<Option name="`record_marker`">
 This block is being applied to all the records present in the current query to fetch the coordinates of off the record.
 
 You may use this block to fetch the coordinates from other places (API calls, cache queries, etc.) rather than the database.
 
 This block has to return a hash compatible with the [`PointMap` items](https://github.com/ankane/mapkick#point-map). Has to have `latitude` and `longitude` and optionally `tooltip`, `label`, or `color`.
-:::
+</Option>
 
-:::option `table`
+<Option name="`table`">
 This is the configuration for the adjacent table. You can set the visibility to `true` or `false`, and set the position of the table `:top`, `:right`, `:bottom`, or `:left`.
-:::
+</Option>
 
 ## Make it the default view
 

--- a/docs/2.0/menu-editor.md
+++ b/docs/2.0/menu-editor.md
@@ -89,7 +89,7 @@ end
 
 A few menu item types are supported `link_to`, `section`, `group`, `resource`, and `dashboard`. There are a few helpers too, like `all_resources`, `all_dashboards`, and `all_tools`.
 
-:::option `link_to`
+<Option name="`link_to`">
 
 Link to is the menu item that the user will probably interact with the most. It will generate a link on your menu. You can specify the `name`, `path` , and `target`.
 
@@ -101,9 +101,9 @@ link_to "Google", path: "https://google.com", target: :_blank
 
 When you add the `target: :_blank` option, a tiny external link icon will be displayed.
 
-:::
+</Option>
 
-:::option `resource`
+<Option name="`resource`">
 
 To make it a bit easier, you can use `resource` to quickly generate a link to one of your resources. For example, you can pass a short symbol name `:user` or the full name `UserResource`.
 
@@ -131,9 +131,9 @@ resource :users, params: -> do
 end
 ```
 
-:::
+</Option>
 
-:::option `dashboard`
+<Option name="`dashboard`">
 
 Similar to `resource`, this is a helper to make it easier to reference a dashboard. You pass in the `id` or the `name` of the dashboard.
 
@@ -150,9 +150,9 @@ You can also change the label for the `dashboard` items to something else.
 dashboard :dashy, label: "Dashy Dashboard"
 ```
 
-:::
+</Option>
 
-:::option `section`
+<Option name="`section`">
 
 Sections are the big categories in which you can group your menu items. They take `name` and `icon` options.
 
@@ -165,9 +165,9 @@ end
 
 <img :src="('/assets/img/menu-editor/section.jpg')" alt="Avo menu editor" class="border mb-4" />
 
-:::
+</Option>
 
-:::option `group`
+<Option name="`group`">
 
 Groups are smaller categories where you can bring together your items.
 
@@ -180,9 +180,9 @@ end
 ```
 
 <img :src="('/assets/img/menu-editor/group.jpg')" alt="Avo menu editor" class="border mb-4" />
-:::
+</Option>
 
-:::option `all_resources`
+<Option name="`all_resources`">
 Renders all resources.
 
 ```ruby
@@ -193,9 +193,9 @@ section "App", icon: "heroicons/outline/beaker" do
 end
 ```
 
-:::
+</Option>
 
-:::option `all_dashboards`
+<Option name="`all_dashboards`">
 Renders all dashboards.
 
 ```ruby
@@ -206,9 +206,9 @@ section "App", icon: "heroicons/outline/beaker" do
 end
 ```
 
-:::
+</Option>
 
-:::option `all_tools`
+<Option name="`all_tools`">
 Renders all tools.
 
 ```ruby
@@ -219,7 +219,7 @@ section "App", icon: "heroicons/outline/beaker" do
 end
 ```
 
-:::
+</Option>
 
 ### `all_` helpers
 
@@ -295,8 +295,6 @@ Avo.configure do |config|
   }
 end
 ```
-
-:::
 
 ## Icons
 

--- a/docs/2.0/native-components/avo-panel-component.md
+++ b/docs/2.0/native-components/avo-panel-component.md
@@ -36,65 +36,65 @@ All options are optional. You may render a panel without options.
 <% end %>
 ```
 
-:::option `name`
+<Option name="`name`">
 The name of the panel. It's displayed on the top under the breadcrumbs.
 
 #### Type
 `String`
 
 ![](/assets/img/native-components/avo-panel-component/name.jpg)
-:::
+</Option>
 
-:::option `description`
+<Option name="`description`">
 Small text under the name that speaks a bit about what the panel does.
 
 #### Type
 `String`
 
 ![](/assets/img/native-components/avo-panel-component/description.jpg)
-:::
+</Option>
 
-:::option `classes`
+<Option name="`classes`">
 A list of classes that should be applied to the panel container.
 
 #### Type
 `String`
 
 ![](/assets/img/native-components/avo-panel-component/classes.jpg)
-:::
+</Option>
 
-:::option `body_classes`
+<Option name="`body_classes`">
 A list of classes that should be applied to the body of panel.
 
 #### Type
 `String`
 
 ![](/assets/img/native-components/avo-panel-component/body_classes.jpg)
-:::
+</Option>
 
-:::option `data`
+<Option name="`data`">
 A hash of data attributes to be forwarded to the panel container.
 
 #### Type
 `Hash`
 
 ![](/assets/img/native-components/avo-panel-component/classes.jpg)
-:::
+</Option>
 
-:::option `display_breadcrumbs`
+<Option name="`display_breadcrumbs`">
 Toggles the breadcrumbs visibility. You can't customize the breadcrumbs yet.
 
 #### Type
 `Boolean`
 
 ![](/assets/img/native-components/avo-panel-component/display_breadcrumbs.jpg)
-:::
+</Option>
 
 ## Slots
 
 The component has a few slots where you customize the content in certain areas.
 
-:::option `tools`
+<Option name="`tools`">
 We created this slot as a place to put resource controls like the back, edit, delete, and detach buttons.
 This slot will collapse under the title and description when the screen resolution falls under `1024px`.
 
@@ -111,9 +111,9 @@ The section is automatically aligned to the right using `justify-end` class.
 ```
 
 ![](/assets/img/native-components/avo-panel-component/tools-slot.jpg)
-:::
+</Option>
 
-:::option `body`
+<Option name="`body`">
 This is one of the main slots of the component where the bulk of the content is displayed.
 
 ```erb{2-4}
@@ -125,9 +125,9 @@ This is one of the main slots of the component where the bulk of the content is 
 ```
 
 ![](/assets/img/native-components/avo-panel-component/body-slot.jpg)
-:::
+</Option>
 
-:::option `bare_content`
+<Option name="`bare_content`">
 Used when displaying the [Grid view](./../grid-view), it displays the data flush in the container and with no background.
 
 ```erb{2-4}
@@ -139,9 +139,9 @@ Used when displaying the [Grid view](./../grid-view), it displays the data flush
 ```
 
 ![](/assets/img/native-components/avo-panel-component/grid-view.jpg)
-:::
+</Option>
 
-:::option `footer_tools`
+<Option name="`footer_tools`">
 This is pretty much the same slot as `tools` but rendered under the `body` or `bare_content` slots.
 
 ```erb{2-4}
@@ -153,9 +153,9 @@ This is pretty much the same slot as `tools` but rendered under the `body` or `b
 ```
 
 ![](/assets/img/native-components/avo-panel-component/footer-controls.jpg)
-:::
+</Option>
 
-:::option `footer`
+<Option name="`footer`">
 The lowest available area at the end of the component.
 
 ```erb{2-4}
@@ -165,9 +165,9 @@ The lowest available area at the end of the component.
   <% end %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `sidebar`
+<Option name="`sidebar`">
 The sidebar will conveniently show things in a smaller area on the right of the `body`.
 
 ```erb{2-4}
@@ -178,9 +178,9 @@ The sidebar will conveniently show things in a smaller area on the right of the 
 <% end %>
 ```
 ![](/assets/img/native-components/avo-panel-component/sidebar.png)
-:::
+</Option>
 
-:::option `bare_sidebar`
+<Option name="`bare_sidebar`">
 Use this instead of `sidebar` to display content in a sidebar without the white background styling.
 
 ```erb{2-4}
@@ -190,4 +190,4 @@ Use this instead of `sidebar` to display content in a sidebar without the white 
   <% end %>
 <% end %>
 ```
-:::
+</Option>

--- a/docs/2.0/resources.md
+++ b/docs/2.0/resources.md
@@ -357,26 +357,26 @@ end
 
 ## Views
 
-:::option `Index`
+<Option name="`Index`">
 
 The page where you see all your resources listed in a table or a [grid](grid-view.html).
 
-:::
-:::option `Show`
+</Option>
+<Option name="`Show`">
 
 The page where you see one resource in more detail.
 
-:::
-:::option `Edit`
+</Option>
+<Option name="`Edit`">
 
 The page where you can edit one resource.
 
-:::
-:::option `New`
+</Option>
+<Option name="`New`">
 
 The page where you can create a new resource.
 
-:::
+</Option>
 
 ### Grid view
 
@@ -568,7 +568,7 @@ end
 This tells Avo which resources you use and stops the eager-loading process on boot-time.
 This means that other resources that are not declared in this array will not show up in your app.
 
-:::option self.pagination
+<Option name="self.pagination">
 <VersionReq version="2.45" />
 This feature is designed for managing pagination. For example on large tables of data sometimes count is inefficient and unnecessary.
 
@@ -644,4 +644,4 @@ self.pagination = -> do
 end
 ```
 ![Countless pagination size empty](/assets/img/resources/pagination/countless_empty_size.png)
-:::
+</Option>

--- a/docs/3.0/actions.md
+++ b/docs/3.0/actions.md
@@ -206,7 +206,7 @@ end
 
 The available action responses are:
 
-:::option `reload`
+<Option name="`reload`">
 
 When you use `reload`, a full-page reload will be triggered.
 
@@ -221,8 +221,8 @@ def handle(query:, **args)
 end
 ```
 
-:::
-:::option `redirect_to`
+</Option>
+<Option name="`redirect_to`">
 
 `redirect_to` will execute a redirect to a new path of your app. It accept `allow_other_host`, `status` and any other arguments.
 
@@ -239,11 +239,13 @@ def handle(query:, **args)
   redirect_to avo.resources_users_path
 end
 ```
+</Option>
 
-:::option `turbo`
+<Option name="`turbo`">
 There are times when you don't want to perform the actions with Turbo. In such cases, turbo should be set to false.
-:::
-:::option `download`
+</Option>
+
+<Option name="`download`">
 
 `download` will start a file download to your specified `path` and `filename`.
 
@@ -251,7 +253,7 @@ There are times when you don't want to perform the actions with Turbo. In such c
 
 If you find another way, please let us know 😅.
 
-::: code-group
+:::code-group
 
 ```ruby{3,18} [app/avo/actions/download_file.rb]
 class Avo::Actions::DownloadFile < Avo::BaseAction
@@ -287,8 +289,9 @@ class Avo::Resources::Project < Avo::BaseResource
 end
 ```
 :::
+</Option>
 
-:::option `keep_modal_open`
+<Option name="`keep_modal_open`">
 
 There might be situations where you want to run an action and if it fails, respond back to the user with some feedback but still keep it open with the inputs filled in.
 
@@ -313,9 +316,9 @@ class Avo::Actions::KeepModalOpenAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
-:::option `close_modal`
+<Option name="`close_modal`">
 <VersionReq version="3.3.0" />
 
 This type of response becomes useful when you are working with a form and need to execute an action without redirecting, ensuring that the form remains filled as it is.
@@ -335,9 +338,9 @@ class Avo::Actions::CloseModal < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
-:::option `do_nothing`
+<Option name="`do_nothing`">
 `do_nothing` is an alias for `close_modal`.
 
 ```ruby{7}
@@ -351,9 +354,9 @@ class Avo::Actions::CloseModal < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
-:::option `navigate_to_action`
+<Option name="`navigate_to_action`">
 <VersionReq version="3.4.2" />
 
 You may want to redirect to another action. Here's an example of how to create a multi-step process, passing arguments from one action to another.
@@ -399,11 +402,12 @@ class Avo::Actions::City::Update < Avo::BaseAction
   end
 end
 ```
-
-You can see this multi-step process in action by visiting the [avodemo](https://main.avodemo.com/avo/resources/cities). Select one of the records, click on the "Update" action, choose the fields to update, and then proceed to update the selected fields in the subsequent action.
 :::
 
-::::option `append_to_response`
+You can see this multi-step process in action by visiting the [avodemo](https://main.avodemo.com/avo/resources/cities). Select one of the records, click on the "Update" action, choose the fields to update, and then proceed to update the selected fields in the subsequent action.
+</Option>
+
+<Option name="`append_to_response`">
 <VersionReq version="3.10.3" />
 
 Avo action responses are in the `turbo_stream` format. You can use the `append_to_response` method to append additional turbo stream responses to the default response.
@@ -423,7 +427,7 @@ The `append_to_response` method accepts a Proc or lambda function. This function
 
 The block should return either a single `turbo_stream` response or an array of multiple `turbo_stream` responses.
 
-::: code-group
+:::code-group
 ```ruby[Array]{2-5}
 append_to_response -> {
   [
@@ -439,7 +443,7 @@ append_to_response -> {
 }
 ```
 :::
-::::
+</Option>
 
 ## Customization
 
@@ -615,7 +619,7 @@ You may want to dynamically generate an action link. For that you need the actio
 
 Let's see an example use case:
 
-::: code-group
+:::code-group
 ```ruby{7,8,9,10,11,12,13,15} [Current Version]
 field :name,
   as: :text,
@@ -688,9 +692,9 @@ def actions
 ```
 <Image src="/assets/img/action_divider.png" width="306" height="325" alt="" />
 
-:::option `label`
+<Option name="`label`">
 You can pass a `label` option to display that text
-:::
+</Option>
 
 ## Icon
 

--- a/docs/3.0/associations/belongs_to.md
+++ b/docs/3.0/associations/belongs_to.md
@@ -17,15 +17,15 @@ You will see three field types when you add a `BelongsTo` association to a model
 
 <!-- @include: ./../common/associations_searchable_option_common.md-->
 
-:::option `allow_via_detaching`
+<Option name="`allow_via_detaching`">
 Keeps the field enabled when visiting from the parent record.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
 <!-- @include: ./../common/associations_attach_scope_option_common.md-->
 
-:::option `polymorphic_as`
+<Option name="`polymorphic_as`">
 Sets the field as polymorphic with the key set on the model.
 
 #### Default
@@ -35,9 +35,9 @@ Sets the field as polymorphic with the key set on the model.
 #### Possible values
 
 A symbol, used on the `belongs_to` association with `polymorphic: true`.
-:::
+</Option>
 
-:::option `types`
+<Option name="`types`">
 Sets the types the field can morph to.
 
 #### Default
@@ -47,9 +47,9 @@ Sets the types the field can morph to.
 #### Possible values
 
 `[Post, Project, Team]`. Any array of model names.
-:::
+</Option>
 
-:::option `polymorphic_help`
+<Option name="`polymorphic_help`">
 Sets the help text for the polymorphic type dropdown. Useful when you need to specify to the user why and what they need to choose as polymorphic.
 
 #### Default
@@ -59,11 +59,11 @@ Sets the help text for the polymorphic type dropdown. Useful when you need to sp
 #### Possible values
 
 Any string.
-:::
+</Option>
 
 <!-- @include: ./../common/associations_use_resource_option_common.md-->
 
-:::option `can_create`
+<Option name="`can_create`">
 Controls the creation link visibility on forms.
 
 #### Default
@@ -78,6 +78,7 @@ Controls the creation link visibility on forms.
 
 In this example, even if the `can_create` option is set to `true`, if the `UserPolicy` responds with `false` to the `create?` method, the creation link will **NOT** be visible.
 :::
+</Option>
 
 ## Overview
 

--- a/docs/3.0/associations/has_many.md
+++ b/docs/3.0/associations/has_many.md
@@ -26,13 +26,13 @@ field :projects, as: :has_many
 <!-- @include: ./../common/search_query_scope_common.md-->
 
 
-:::option `linkable`
+<Option name="`linkable`">
 You can add use this option to make the association title clickable. That link will open a new page with the same view.
 
 This feature doesn't go deeper than this. It just helps you see the association table easier in a separate page.
 
 <Image src="/assets/img/3_0/has_many/linkable.gif" width="1200" height="875" alt="" />
-:::
+</Option>
 
 ## Has Many Through
 

--- a/docs/3.0/authorization.md
+++ b/docs/3.0/authorization.md
@@ -60,37 +60,37 @@ These methods control whether the resource appears on the sidebar, if the view/e
 
 </Option>
 
-:::option `show?`
+<Option name="`show?`">
 
 When setting `show?` to `false`, the user will not see the show icon on the resource row and will not have access to the **Show** view of a resource.
 
-:::
+</Option>
 
-:::option `create?`
+<Option name="`create?`">
 
 The `create?` method will prevent the users from creating a resource. That will also apply to the `Create new {model}` button on the <Index />, the `Save` button on the `/new` page, and `Create new {model}` button on the association `Show` page.
 
-:::
+</Option>
 
-:::option `new?`
+<Option name="`new?`">
 
 The `new?` method will control whether the users can save the new resource. You can also access the `record` variable with the form values pre-filled.
 
-:::
+</Option>
 
-:::option `edit?`
+<Option name="`edit?`">
 
 `edit?` to `false` will hide the edit button on the resource row and prevent the user from seeing the edit view.
 
-:::
+</Option>
 
-:::option `update?`
+<Option name="`update?`">
 
 `update?` to `false` will prevent the user from updating a resource. You can also access the `record` variable with the form values pre-filled.
 
-:::
+</Option>
 
-::::option `destroy?`
+<Option name="`destroy?`">
 
 `destroy?` to `false` will prevent the user from destroying a resource and hiding the delete button.
 
@@ -98,26 +98,26 @@ The `new?` method will control whether the users can save the new resource. You 
 These are per-resource and general settings. If you want to control the authorization per individual file, please see the [granular settings](#attachments).
 :::
 
-::::
+</Option>
 
-:::option `act_on?`
+<Option name="`act_on?`">
 
 Controls whether the user can see the actions button on the <Index /> page.
 
-:::
+</Option>
 
-:::option `reorder?`
+<Option name="`reorder?`">
 
 Controls whether the user can see the [records reordering](./records-reordering) buttons on the <Index /> page.
 
 <Image src="/assets/img/authorization/actions_button.jpg" width="1220" height="632" alt="Actions button" />
 
-:::
+</Option>
 
-:::option `search?`
+<Option name="`search?`">
 
 Controls whether the user can see the global search input or the [resource search input](./search) on top of the <Index /> page.
-:::
+</Option>
 
 ## Associations
 
@@ -138,26 +138,26 @@ We'll have this example of a `Post` resource with many `Comment`s through the `h
 In the `Post` `has_many` `Comments` example, when you want to authorize `show_comments?` in `PostPolicy` you will have a `Comment` instance as the `record` variable, but when you try to authorize the `attach_comments?`, you won't have that `Comment` instance because you want to create one, but we expose the parent `Post` instance so you have more information about that authorization action that you're trying to make.
 :::
 
-:::option `attach_{association}?`
+<Option name="`attach_{association}?`">
 
 Controls whether the `Attach comment` button is visible. The `record` variable is the parent record (a `Post` instance in our scenario).
 
 <Image src="/assets/img/authorization/attach.jpg" width="1224" height="692" alt="" />
 
-:::
-:::option `detach_{association}?`
+</Option>
+<Option name="`detach_{association}?`">
 
 Controls whether the **detach button is available** on the associated record row on the <Index /> view. The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
 <Image src="/assets/img/authorization/detach.jpg" width="1224" height="692" alt="" />
 
-:::
-:::option `view_{association}?`
+</Option>
+<Option name="`view_{association}?`">
 
 Controls whether the whole association is being displayed on the parent record. The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
-:::
-::::option `show_{association}?`
+</Option>
+<Option name="`show_{association}?`">
 
 Controls whether the **view button is visible** on the associated record row on the <Index /> page. The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
@@ -175,8 +175,8 @@ When you use the `view_comments?` policy method you get the `Post` instance as t
 When you use `show_comments?` policy method, the `record` variable is each `Comment` instance and you control whether the view button is displayed on each individual row.
 :::
 
-::::
-::::option `edit_{association}?`
+</Option>
+<Option name="`edit_{association}?`">
 
 Controls whether the **edit button is visible** on the associated record row on the <Index /> page.The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
@@ -185,33 +185,33 @@ This **does not** control whether the user has access to that record's edit page
 :::
 
 <Image src="/assets/img/authorization/edit.jpg" width="1224" height="692" alt="" />
+</Option>
 
-::::
-:::option `create_{association}?`
+<Option name="`create_{association}?`">
 
 Controls whether the `Create comment` button is visible. The `record` variable is the parent record (a `Post` instance in our scenario).
 
 <Image src="/assets/img/authorization/create.jpg" width="1224" height="692" alt="" />
 
-:::
-:::option `destroy_{association}?`
+</Option>
+<Option name="`destroy_{association}?`">
 
 Controls whether the **delete button is visible** on the associated record row on the <Index /> page.The `record` variable is the actual row record (a `Comment` instance in our scenario).
 
 <Image src="/assets/img/authorization/destroy.jpg" width="1224" height="692" alt="" />
 
-:::
-:::option `act_on_{association}?`
+</Option>
+<Option name="`act_on_{association}?`">
 
 Controls whether the `Actions` dropdown is visible. The `record` variable is the parent record (a `Post` instance in our scenario).
 
 <Image src="/assets/img/authorization/actions.jpg" width="1224" height="692" alt="" />
 
-:::
-:::option `reorder_{association}?`
+</Option>
+<Option name="`reorder_{association}?`">
 
 Controls whether the user can see the [records reordering](./records-reordering) buttons on the `has_many` <Index /> page.
-:::
+</Option>
 
 ## Removing duplication
 
@@ -323,17 +323,17 @@ Both the `record` and the `user` will be available for you to access.
 
 <Image src="/assets/img/authorization/file_actions.png" width="472" height="93" alt="" />
 
-:::option `upload_{FIELD_ID}?`
+<Option name="`upload_{FIELD_ID}?`">
 Controls whether the user can upload the attachment.
-:::
+</Option>
 
-:::option `download_{FIELD_ID}?`
+<Option name="`download_{FIELD_ID}?`">
 Controls whether the user can download the attachment.
-:::
+</Option>
 
-:::option `delete_{FIELD_ID}?`
+<Option name="`delete_{FIELD_ID}?`">
 Controls whether the user can destroy the attachment.
-:::
+</Option>
 
 :::info AUTHORIZE IN BULK
 If you want to allow or disallow these methods in bulk you can use a little meta-programming to assign all the same value.
@@ -463,7 +463,7 @@ end
 
 Each authorization client must expose a few methods.
 
-:::option `authorize`
+<Option name="`authorize`">
 
 Receives the `user`, `record`, `action`, and optionally, the `policy_class` (you may want to use custom policy classes for some resources).
 
@@ -478,8 +478,8 @@ rescue Pundit::NotAuthorizedError => error
 end
 ```
 
-:::
-:::option `policy`
+</Option>
+<Option name="`policy`">
 
 Receives the `user` and `record` and returns the policy to use.
 
@@ -489,8 +489,8 @@ def policy(user, record)
 end
 ```
 
-:::
-:::option `policy!`
+</Option>
+<Option name="`policy!`">
 
 Receives the `user` and `record` and returns the policy to use. It will raise an error if no policy is found.
 
@@ -502,8 +502,8 @@ rescue Pundit::NotDefinedError => error
 end
 ```
 
-:::
-:::option `apply_policy`
+</Option>
+<Option name="`apply_policy`">
 
 Receives the `user`, `record`, and optionally, the policy class to use. It will apply a scope to a query.
 
@@ -523,7 +523,7 @@ rescue Pundit::NotDefinedError => error
   raise NoPolicyError.new error.message
 end
 ```
-:::
+</Option>
 
 ## Rolify integration
 

--- a/docs/3.0/avo-2-avo-3-upgrade.md
+++ b/docs/3.0/avo-2-avo-3-upgrade.md
@@ -64,7 +64,7 @@ Each paragraph will guide you through the upgrade process for each individual ch
 
 Most of these steps are breaking changes so you'll need to apply them if you're using the feature.
 
-:::option Update your `Gemfile`
+<Option name="Update your `Gemfile`">
 The Avo gem comes in three flavors now. Community, Pro, or Advanced.
 
 You should add the one you use in your `Gemfile`. If you use Pro or Advanced you don't have to add `avo` too. Each gem adds their own dependencies.
@@ -76,8 +76,9 @@ Add only one of the ones below.
 :::warning
 If you want to install `avo-pro` or `avo-advanced` please ensure you have a [valid Avo 3 license](https://avohq.io/pricing) and you [take the required steps to authenticate](./gem-server-authentication) with `packager.dev`.
 :::
+</Option>
 
-:::option The status field changed behavior
+<Option name="The status field changed behavior">
 Before, for the status you'd set the `failed` and `loading` states and everything else fell under `success`. That felt unnatural. We needed a `neutral` state.
 Now we changed the field so you'll set the `failed`, `loading`, and `success` values and the rest fall under `neutral`.
 
@@ -95,9 +96,9 @@ field :status,
   loading_when: :loading
   success_when: :deployed # specify the success state
 ```
-:::
+</Option>
 
-:::option `heading` has become a field type
+<Option name="`heading` has become a field type">
 Before, a heading used the `heading` method with a text string or HTML string as an argument.
 Now, it is a field type with an ID. It supports rendering as text and as HTML.
 
@@ -122,9 +123,9 @@ field :some_id, as: :heading, as_html: true do
   '<div class="underline uppercase font-bold">User Information</div>'
 end
 ```
-:::
+</Option>
 
-:::option Moved some globals from `Avo::App` to `Avo::Current`
+<Option name="Moved some globals from `Avo::App` to `Avo::Current`">
 
 ### Actions to take
 
@@ -137,9 +138,9 @@ Rename the following:
 - `Avo::App.current_user` -> `Avo::Current.user`
 
 Make note of the `current_user` to `user` rename.
-:::
+</Option>
 
-:::option Renamed `model` to `record` across all configuration files
+<Option name="Renamed `model` to `record` across all configuration files">
 
 The `model` naming is a bit off. You never know if you're mentioning the model class or the instantiated database record, so we changed it to `record` (Pundit calls it a record too). One of the places you'll see it the most is when you reference it off of the `resource` (`resource.model`).
 
@@ -149,9 +150,9 @@ Rename `resource.model` to `resource.record`.
 
 You might have the `model` referenced in other places too. Try to replace it with `record`.
 If you find it in other places, please send them our way so we can update this doc for a more consistent API. Thank you!
-:::
+</Option>
 
-:::option Remove block (lambda) arguments
+<Option name="Remove block (lambda) arguments">
 
 All block arguments are removed from Avo. We did this in order to make blocks more consistent and to improve future compatibility. All the arguments that were previously available as arguments, are present inside the block.
 
@@ -200,9 +201,9 @@ field :level, as: :select, options: -> do
     }
   end
 ```
-:::
+</Option>
 
-:::option Swap `disabled` and `readonly` field options
+<Option name="Swap `disabled` and `readonly` field options">
 
 We received some feedback in v2.x that the `disabled` field option does not protect against DOM field manipulation when the form is submitted, so we introduced the `readonly` option that protects against that.
 
@@ -224,9 +225,9 @@ field :hidden_info,
   readonly: -> { !Avo::Current.user.is_admin? } // [!code --]
   disabled: -> { !Avo::Current.user.is_admin? } // [!code ++]
 ```
-:::
+</Option>
 
-:::option Removed `index_text_align` option
+<Option name="Removed `index_text_align` option">
 Same behavior from `index_text_align` can be achieved using `html` and `class` options.
 
 ### Actions to take
@@ -239,9 +240,9 @@ field :users_required, as: :number, index_text_align: :right
 # After
 field :users_required, as: :number, html: {index: {wrapper: {classes: "text-right"}}}
 ```
-:::
+</Option>
 
-:::option Renamed `resolve_query_scope` to `index_query` in resources
+<Option name="Renamed `resolve_query_scope` to `index_query` in resources">
 The new method name `index_query` speaks more about what it does and the rest of the changes brings it more inline with the other APIs
 
 ### Actions to take
@@ -261,9 +262,9 @@ self.index_query = -> do
   query.order(last_name: :asc)
 end
 ```
-:::
+</Option>
 
-:::option Removed `resolve_find_scope` in favor of `find_record_method`
+<Option name="Removed `resolve_find_scope` in favor of `find_record_method`">
 The new `find_record_method` method works better as it enables you to use custom find matchers.
 
 ### Actions to take
@@ -284,9 +285,9 @@ self.find_record_method = -> do
   query.friendly.find id
 end
 ```
-:::
+</Option>
 
-:::option Refactor the grid view API
+<Option name="Refactor the grid view API">
 We removed the old `grid do` block to `self.grid_view` to fall more inline with `self.map_view` and others.
 
 The `card` block will cycle through all of your records and you need to return a hash with the following keys `title`, `body`, `cover_url`.
@@ -325,9 +326,9 @@ self.grid_view = {
   end
 }
 ```
-:::
+</Option>
 
-:::option Refactored the search API
+<Option name="Refactored the search API">
 In Avo 2, the search options were scattered around multiple places. The query was used from the `search_query`, the record description was taken from an arbitrary `as_description: true` field option, and other mis-aligned places.
 
 In Avo 3 we brought all those things in a single `self.search` option.
@@ -366,9 +367,9 @@ class Avo::Resources::User < Avo::BaseResource
   }
 end
 ```
-:::
+</Option>
 
-::::option Rename Avo configuration classes
+<Option name="Rename Avo configuration classes">
 
 We are falling more in line with how Rails and zeitwerk autoloads classes. We do this to avoid some issues like class conflicts and difficult to remember naming schemes.
 
@@ -467,9 +468,9 @@ class Avo::Fields::ColorPickerField < Avo::Fields::BaseField
 end
 ```
 :::
-::::
+</Option>
 
-:::option Use the `def fields` API
+<Option name="Use the `def fields` API">
 We are introducing a new API for declaring fields. This brings many improvements from easier maintenance, better control, better composition, and more.
 
 ```ruby
@@ -559,9 +560,9 @@ end
 ### Actions to take
 
 Wrap all `field`, `tabs`, `tab`, `panel`, `sidebar`, and `tool` declarations from Resource and Action files into one `def fields` method.
-:::
+</Option>
 
-:::option Use the `def actions` API
+<Option name="Use the `def actions` API">
 Similar to how we added the `def fields` wrapper to fields you should now wrap all actions in an `actions` method.
 
 
@@ -578,9 +579,9 @@ class Avo::Resources::User < Avo::BaseResource
   end
 end
 ```
-:::
+</Option>
 
-:::option Use the `def filters` API
+<Option name="Use the `def filters` API">
 Similar to how we added the `def fields` wrapper to fields you should now wrap all filters in an `filters` method.
 
 
@@ -597,9 +598,9 @@ class Avo::Resources::User < Avo::BaseResource
   end
 end
 ```
-:::
+</Option>
 
-:::option Use the `def scopes` API
+<Option name="Use the `def scopes` API">
 Similar to how we added the `def fields` wrapper to fields you should now wrap all scopes in an `scopes` method.
 
 
@@ -616,9 +617,9 @@ class Avo::Resources::User < Avo::BaseResource
   end
 end
 ```
-:::
+</Option>
 
-:::option Wrap all Dashboard `card` and `divider` definitions inside one `def cards` method
+<Option name="Wrap all Dashboard `card` and `divider` definitions inside one `def cards` method">
 After the `def fields` refactor we did the same in dashboard files. Instead of declaring the cards in the class directly, you should do it in the `def cards` method.
 
 ```ruby{6-9,17-22}
@@ -646,9 +647,9 @@ class Avo::Dashboards::Dashy < Avo::Dashboards::BaseDashboard
   end
 end
 ```
-:::
+</Option>
 
-:::option `tool` is declared inside the `def fields` method
+<Option name="`tool` is declared inside the `def fields` method">
 In Avo 3 you'll be able to insert resource tools in-between fields, tabs and panels, so now, the `tool`s must be called inside the `fields` method. This feature is unreleased yet, but you should make the change now so it'll be seamless when we add it.
 
 ### Actions to take
@@ -674,9 +675,9 @@ class Avo::Resources::User < Avo::BaseResource
   end
 end
 ```
-:::
+</Option>
 
-:::option Remove `tabs_style` from the `tabs` declaration
+<Option name="Remove `tabs_style` from the `tabs` declaration">
 We streamlined tabs and kept only the `:pills` style so now we only have one style of tabs.
 
 ### Actions to take
@@ -694,4 +695,4 @@ tabs do
   # tabs here
 end
 ```
-:::
+</Option>

--- a/docs/3.0/avo-current.md
+++ b/docs/3.0/avo-current.md
@@ -4,41 +4,41 @@
 
 On each request Avo will set some values on it.
 
-:::option `user`
+<Option name="`user`">
 This is what will be returned by the [`current_user_method`](./authentication.html#customize-the-current-user-method) that you've set in your initializer.
-:::
+</Option>
 
-:::option `params`
+<Option name="`params`">
 Equivalent of `request.params`.
-:::
+</Option>
 
-:::option `request`
+<Option name="`request`">
 The Rails `request`.
-:::
+</Option>
 
-:::option `context`
+<Option name="`context`">
 The [`context`](./customization.html#context) that you configured in your initializer evaluated in `Avo::ApplicationController`.
-:::
+</Option>
 
-:::option `view_context`
+<Option name="`view_context`">
 An instance of [`ActionView::Rendering`](https://api.rubyonrails.org/classes/ActionView/Rendering.html#method-i-view_context) off of which you can run any methods or variables that are available in your partials.
 
 ```ruby
 view_context.link_to "Avo", "https://avohq.io"
 ```
-:::
+</Option>
 
-:::option `locale`
+<Option name="`locale`">
 The `locale` of the app.
-:::
+</Option>
 
-:::option `tenant_id`
+<Option name="`tenant_id`">
 You can set the `tenant_id` for the current request.
-:::
+</Option>
 
-:::option `tenant`
+<Option name="`tenant`">
 You can set the `tenant` for the current request.
-:::
+</Option>
 
 **Related:**
   - [Multitenancy](./multitenancy)

--- a/docs/3.0/basic-filters.md
+++ b/docs/3.0/basic-filters.md
@@ -10,12 +10,12 @@ Each filter is configured in a class with a few dedicated [methods and options](
 
 ## Filter options
 
-:::option `self.name`
+<Option name="`self.name`">
 
 `self.name` is what is going to be displayed to the user in the filters panel.
-:::
+</Option>
 
-:::option `self.visible`
+<Option name="`self.visible`">
 
 You may want to show/hide the filter in some scenarios. You can do that using the `self.visible` attribute.
 
@@ -36,39 +36,39 @@ Inside the visible block you can acces the following variables and you should re
     true
   end
 ```
-:::
+</Option>
 
-:::option `self.empty_message`
+<Option name="`self.empty_message`">
 There might be times when you will want to show a message to the user when you're not returning any options.
 
 More on this in the [Empty message guide](#empty-message-text).
-:::
-:::option `options`
+</Option>
+<Option name="`options`">
 Some filters allow you to pass options to the user. For example on the [select filter](#select_filter) you can set the options in the dropdown, and on the [boolean filter](#boolean_filter) you may set the checkbox values.
 Each filter type has their own `options` configuration explained below.
 
 In the `options` method you have access to the `request`, `params`, [`context`](./customization#context), `view_context`, and `current_user` objects.
-:::
+</Option>
 
-:::option `apply`
+<Option name="`apply`">
 The `apply` method is what is going to be run when Avo fetches the records on the <Index /> view.
 
 It recieves the `request` form which you can get all the `params` if you need them, it gets the `query` which is the query Avo made to fetch the records. It's a regular [Active Record](https://guides.rubyonrails.org/active_record_querying.html) which you can manipulate.
 
 It also receives the `values` variable which holds the actual choices the user made on the front-end for the [options](#options) you set.
-:::
+</Option>
 
-:::option `default`
+<Option name="`default`">
 You may set default values for the `options` you set. For example you may set which option to be selected for the [select filter](#select_filter) and which checkboxes to be set for the [boolean filter](#boolean_filter).
 
 In the `default` method you have access to the `request`, `params`, [`context`](./customization#context), `view_context`, and `current_user` objects.
-:::
+</Option>
 
-:::option `react`
+<Option name="`react`">
 This is a hook in which you can change the value of the filter based on what other filters have for values.
 
 More on this in the [React to filters guide](#react-to-filters)
-:::
+</Option>
 
 ## Register filters
 
@@ -98,7 +98,7 @@ Avo has several types of filters available [Boolean filter](#boolean_filter), [S
 
 Because the filters get serialized back and forth, the final `value`/`values` in the `apply` method will be stringified or have the stringified keys if they are hashes. You can declare them as regular hashes in the `options` method, but they will get stringified.
 
-:::option Boolean Filter
+<Option name="Boolean Filter">
 
 The boolean filter is a filter where the user can filter the records using one or more checkboxes.
 
@@ -201,9 +201,9 @@ class Avo::Filters::Featured < Avo::Filters::BooleanFilter
   end
 end
 ```
-:::
+</Option>
 
-:::option Select Filter
+<Option name="Select Filter">
 
 Select filters are similar to Boolean ones but they give the user a dropdown with which to filter the values.
 
@@ -277,9 +277,9 @@ class Avo::Filters::Published < Avo::Filters::SelectFilter
   end
 end
 ```
-:::
+</Option>
 
-:::option Multiple select filter
+<Option name="Multiple select filter">
 
 You may also use a multiple select filter.
 
@@ -349,9 +349,9 @@ class Avo::Filters::Author < Avo::Filters::SelectFilter
   end
 end
 ```
-:::
+</Option>
 
-:::option Text Filter
+<Option name="Text Filter">
 
 You can add complex text filters to Avo using the Text filter
 
@@ -375,7 +375,7 @@ class Avo::Filters::Name < Avo::Filters::TextFilter
   # end
 end
 ```
-:::
+</Option>
 
 ## Dynamic filter options
 
@@ -707,7 +707,7 @@ You may want to redirect users to filtered states of the <Index /> view from oth
 
 ### Rails helpers
 
-:::option `decode_filter_params`
+<Option name="`decode_filter_params`">
 
 Decodes the `filters` param. This Rails helper can be used anywhere in a view or off the `view_context`.
 
@@ -729,9 +729,9 @@ class Avo::Actions::DummyAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
-:::option `encode_filter_params`
+<Option name="`encode_filter_params`">
 
 Encodes a `filters` object into a serialized state that Avo understands. This Rails helper can be used anywhere in a view or off the `view_context`.
 
@@ -754,11 +754,11 @@ class Avo::Actions::DummyAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
 ### Standalone helpers
 
-:::option `Avo::Filters::BaseFilter.decode_filters`
+<Option name="`Avo::Filters::BaseFilter.decode_filters`">
 
 Decodes the `filters` param. This standalone method can be used anywhere.
 
@@ -775,9 +775,9 @@ class Avo::Actions::DummyAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>
 
-:::option `Avo::Filters::BaseFilter.encode_filters`
+<Option name="`Avo::Filters::BaseFilter.encode_filters`">
 
 Encodes a `filters` object into a serialized state that Avo understands. This standalone method can be used anywhere.
 
@@ -794,4 +794,4 @@ class Avo::Actions::DummyAction < Avo::BaseAction
   end
 end
 ```
-:::
+</Option>

--- a/docs/3.0/common/association.md
+++ b/docs/3.0/common/association.md
@@ -1,4 +1,4 @@
-:::option `association`
+<Option name="`association`">
 
 <VersionReq version="3.6.2" />
 
@@ -14,3 +14,4 @@ field :special_reviews,
   for_attribute: :reviews,
   scope: -> { query.special_reviews }
 ```
+</Option>

--- a/docs/3.0/common/associations_attach_scope_option_common.md
+++ b/docs/3.0/common/associations_attach_scope_option_common.md
@@ -1,4 +1,4 @@
-:::option `attach_scope`
+<Option name="`attach_scope`">
 Scope out the records the user sees on the Attach modal.
 
 #### Default
@@ -14,7 +14,7 @@ field :user,
 ```
 
 Pass in a block where you attach scopes to the `query` object and `parent` object, which is the actual record where you want to assign the association. The block is executed in the [`ExecutionContext`](./../execution-context).
-:::
+</Option>
 
 :::warning
 The `attach_scope` will not filter the records in the listing from `has_many` or `has_and_belongs_to_many` associations.

--- a/docs/3.0/common/associations_description_option_common.md
+++ b/docs/3.0/common/associations_description_option_common.md
@@ -1,4 +1,4 @@
-:::option `description`
+<Option name="`description`">
 Changes the text displayed under the association name.
 
 <Image src="/assets/img/associations/description-option.jpg" width="702" height="198" alt="" />
@@ -10,4 +10,4 @@ Changes the text displayed under the association name.
 #### Possible values
 
 Any string.
-:::
+</Option>

--- a/docs/3.0/common/associations_discreet_pagination_option_common.md
+++ b/docs/3.0/common/associations_discreet_pagination_option_common.md
@@ -1,4 +1,4 @@
-:::option `discreet_pagination`
+<Option name="`discreet_pagination`">
 Hides the pagination details when only there's only one page for that association.
 
 #### Default
@@ -8,4 +8,4 @@ Hides the pagination details when only there's only one page for that associatio
 #### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/3.0/common/associations_hide_search_input_option_common.md
+++ b/docs/3.0/common/associations_hide_search_input_option_common.md
@@ -1,4 +1,4 @@
-:::option `hide_search_input`
+<Option name="`hide_search_input`">
 Hides the search input displayed on the association table.
 
 #### Default
@@ -8,4 +8,4 @@ Hides the search input displayed on the association table.
 #### Possible values
 
 `true`, `false`.
-:::
+</Option>

--- a/docs/3.0/common/associations_link_to_child_resource_common.md
+++ b/docs/3.0/common/associations_link_to_child_resource_common.md
@@ -1,4 +1,4 @@
-:::option `link_to_child_resource`
+<Option name="`link_to_child_resource`">
 
 Sets which resource should be used in an STI scenario.
 
@@ -11,4 +11,4 @@ See more on this in the [STI section](./../associations#link-to-child-resource-w
 #### Possible values
 
 `true`, `false`.
-:::
+</Option>

--- a/docs/3.0/common/associations_scope_option_common.md
+++ b/docs/3.0/common/associations_scope_option_common.md
@@ -1,4 +1,4 @@
-:::option `scope`
+<Option name="`scope`">
 Scope out the records displayed in the table.
 
 #### Default
@@ -14,4 +14,4 @@ field :user,
 ```
 
 Pass in a block where you attach scopes to the `query` object. The block gets executed in the [`ExecutionContext`](./../execution-context).
-:::
+</Option>

--- a/docs/3.0/common/associations_searchable_option_common.md
+++ b/docs/3.0/common/associations_searchable_option_common.md
@@ -1,4 +1,4 @@
-::::option `searchable`
+<Option name="`searchable`">
 
 <div class="space-x-2">
   <LicenseReq license="pro" />
@@ -39,4 +39,4 @@ end
 #### Possible values
 
 `true`, `false`
-::::
+</Option>

--- a/docs/3.0/common/associations_use_resource_option_common.md
+++ b/docs/3.0/common/associations_use_resource_option_common.md
@@ -1,4 +1,4 @@
-:::option `use_resource`
+<Option name="`use_resource`">
 Sets a different resource to be used when displaying (or redirecting to) the association table.
 
 #### Default
@@ -18,4 +18,4 @@ Avo::Resources::Post
 # the stirng representation of the class
 "Avo::Resources::Post"
 ```
-:::
+</Option>

--- a/docs/3.0/common/date_date_time_common.md
+++ b/docs/3.0/common/date_date_time_common.md
@@ -1,4 +1,4 @@
-:::option `first_day_of_week`
+<Option name="`first_day_of_week`">
 Set which should be the first date of the week in the picker calendar. Flatpickr [documentation](https://flatpickr.js.org/localization/) on that. 1 is Monday, and 7 is Sunday.
 
 #### Default value
@@ -8,9 +8,9 @@ Set which should be the first date of the week in the picker calendar. Flatpickr
 #### Possible values
 
 `1`, `2`, `3`, `4`, `5`, `6`, and `7`
-:::
+</Option>
 
-:::option `disable_mobile`
+<Option name="`disable_mobile`">
 By default, flatpickr is [disabled on mobile](https://flatpickr.js.org/mobile-support/) because the mobile date pickers tend to give a better experience, but you can override that using `disable_mobile: true` (misleading to set it to `true`, I know. We're just forwarding the option). So that will override that behavior and display flatpickr on mobile devices too.
 
 #### Default value
@@ -20,4 +20,4 @@ By default, flatpickr is [disabled on mobile](https://flatpickr.js.org/mobile-su
 #### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/3.0/common/file_options_common.md
+++ b/docs/3.0/common/file_options_common.md
@@ -1,4 +1,4 @@
-:::option `accept`
+<Option name="`accept`">
 Instructs the input to accept only a particular file type for that input using the `accept` option.
 
 ```ruby
@@ -12,9 +12,9 @@ field :cover_video, as: :file, accept: "image/*"
 #### Possible values
 
 `image/*`, `audio/*`, `doc/*`, or any other types from [the spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept).
-:::
+</Option>
 
-:::option `direct_upload`
+<Option name="`direct_upload`">
 <LicenseReq license="pro" />
 
 If you have large files and don't want to overload the server with uploads, you can use the `direct_upload` feature, which will upload the file directly to your cloud provider.
@@ -24,9 +24,9 @@ field :cover_video, as: :file, direct_upload: true
 ```
 
 <!-- @include: ./default_boolean_false.md -->
-:::
+</Option>
 
-:::option `display_filename`
+<Option name="`display_filename`">
 Option that specify if the file should have the caption present or not.
 
 ```ruby
@@ -40,4 +40,4 @@ field :cover_video, as: :file, display_filename: false
 #### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/3.0/common/link_to_record_common.md
+++ b/docs/3.0/common/link_to_record_common.md
@@ -1,3 +1,3 @@
-:::option `link_to_record`
+<Option name="`link_to_record`">
 Wraps the content into an anchor that links to the resource.
-:::
+</Option>

--- a/docs/3.0/common/reloadable.md
+++ b/docs/3.0/common/reloadable.md
@@ -1,4 +1,4 @@
-:::option Reloadable
+<Option name="Reloadable">
 
 <VersionReq version="3.3.6" />
 
@@ -32,3 +32,4 @@ In the above example, the reloadable will be visible if the current_user is an a
 The reloadable block executes within the [`ExecutionContext`](./../execution-context), granting access to all default methods and attributes.
 
 <Image src="/assets/img/reloadable.png" width="680" height="94" alt="Reloadable" />
+</Option>

--- a/docs/3.0/controllers.md
+++ b/docs/3.0/controllers.md
@@ -24,7 +24,7 @@ In order to make your controllers more flexible, there are several overridable m
 ## Create methods
 For the `create` method, you can modify the `after_create_path`, the messages, and the actions both on success or failure.
 
-:::option `after_create_path`
+<Option name="`after_create_path`">
 Overriding this method, you can tell Avo what path to follow after a record was created with success.
 
 ```ruby
@@ -32,9 +32,9 @@ def after_create_path
   "/avo/resources/users"
 end
 ```
-:::
+</Option>
 
-:::option `create_success_action`
+<Option name="`create_success_action`">
 Override this method to create a custom response when a record was created with success.
 
 ```ruby
@@ -44,9 +44,9 @@ def create_success_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `create_fail_action`
+<Option name="`create_fail_action`">
 Override this method to create a custom response when a record failed to be created.
 
 ```ruby
@@ -57,9 +57,9 @@ def create_fail_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `create_success_message`
+<Option name="`create_success_message`">
 Override this method to change the message the user receives when a record was created with success.
 
 ```ruby
@@ -67,9 +67,9 @@ def create_success_message
   "#{@resource.name} #{t("avo.was_successfully_created")}."
 end
 ```
-:::
+</Option>
 
-:::option `create_fail_message`
+<Option name="`create_fail_message`">
 Override this method to change the message the user receives when a record failed to be created.
 
 ```ruby
@@ -77,12 +77,12 @@ def create_fail_message
   t "avo.you_missed_something_check_form"
 end
 ```
-:::
+</Option>
 
 ## Update methods
 For the `update` method, you can modify the `after_update_path`, the messages, and the actions both on success or failure.
 
-:::option `after_update_path`
+<Option name="`after_update_path`">
 Overriding this method, you can tell Avo what path to follow after a record was updated with success.
 
 ```ruby
@@ -90,9 +90,9 @@ def after_update_path
   "/avo/resources/users"
 end
 ```
-:::
+</Option>
 
-:::option `update_success_action`
+<Option name="`update_success_action`">
 Override this method to create a custom response when a record was updated with success.
 
 ```ruby
@@ -102,9 +102,9 @@ def update_success_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `update_fail_action`
+<Option name="`update_fail_action`">
 Override this method to create a custom response when a record failed to be updated.
 
 ```ruby
@@ -115,9 +115,9 @@ def update_fail_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `update_success_message`
+<Option name="`update_success_message`">
 Override this method to change the message the user receives when a record was updated with success.
 
 ```ruby
@@ -125,9 +125,9 @@ def update_success_message
   "#{@resource.name} #{t("avo.was_successfully_updated")}."
 end
 ```
-:::
+</Option>
 
-:::option `update_fail_message`
+<Option name="`update_fail_message`">
 Override this method to change the message the user receives when a record failed to be updated.
 
 ```ruby
@@ -135,12 +135,12 @@ def update_fail_message
   t "avo.you_missed_something_check_form"
 end
 ```
-:::
+</Option>
 
 ## Destroy methods
 For the `destroy` method, you can modify the `after_destroy_path`, the messages, and the actions both on success or failure.
 
-:::option `after_destroy_path`
+<Option name="`after_destroy_path`">
 Overriding this method, you can tell Avo what path to follow after a record was destroyed with success.
 
 ```ruby
@@ -148,9 +148,9 @@ def after_update_path
   "/avo/resources/users"
 end
 ```
-:::
+</Option>
 
-:::option `destroy_success_action`
+<Option name="`destroy_success_action`">
 Override this method to create a custom response when a record was destroyed with success.
 
 ```ruby
@@ -160,9 +160,9 @@ def destroy_success_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `destroy_fail_action`
+<Option name="`destroy_fail_action`">
 Override this method to create a custom response when a record failed to be destroyed.
 
 ```ruby
@@ -172,9 +172,9 @@ def destroy_fail_action
   end
 end
 ```
-:::
+</Option>
 
-:::option `destroy_success_message`
+<Option name="`destroy_success_message`">
 Override this method to change the message the user receives when a record was destroyed with success.
 
 ```ruby
@@ -182,9 +182,9 @@ def destroy_success_message
   t("avo.resource_destroyed", attachment_class: @attachment_class)
 end
 ```
-:::
+</Option>
 
-:::option `destroy_fail_message`
+<Option name="`destroy_fail_message`">
 Override this method to change the message the user receives when a record failed to be destroyed.
 
 ```ruby
@@ -192,6 +192,6 @@ def destroy_fail_message
   @errors.present? ? @errors.join(". ") : t("avo.failed")
 end
 ```
-:::
+</Option>
 
 

--- a/docs/3.0/cover-and-profile-photos.md
+++ b/docs/3.0/cover-and-profile-photos.md
@@ -30,7 +30,7 @@ self.profile_photo = {
 }
 ```
 
-:::option `visible_on`
+<Option name="`visible_on`">
 This controls where the cover photo should be displayed.
 
 It defaults to the <Show />, <Edit />, and <New /> views, but you can change that to be displayed to the <Index /> view or a combination of views.
@@ -48,9 +48,9 @@ It defaults to the <Show />, <Edit />, and <New /> views, but you can change tha
 You may choose one view or a combination of them using an array.
 
 `:show`, `:edit`, `:new`, `:index`, `:forms`, `:display`, `[:show, :edit]`;
-:::
+</Option>
 
-:::option `source`
+<Option name="`source`">
 This controls what should be displayed as the image.
 
 You can call a field on the record using a `Symbol`, or you can open a block where you have access to the `record` and add your own value.
@@ -84,7 +84,7 @@ self.profile_photo = {
   }
 }
 ```
-:::
+</Option>
 
 ## Cover photo
 
@@ -106,7 +106,7 @@ self.cover_photo = {
 }
 ```
 
-:::option `size`
+<Option name="`size`">
 This represents the height of the cover photo. It can be small, medium or large.
 
 ##### Optional
@@ -120,9 +120,9 @@ This represents the height of the cover photo. It can be small, medium or large.
 #### Possible values
 
 `:sm`, `:md`, or `:lg`
-:::
+</Option>
 
-:::option `visible_on`
+<Option name="`visible_on`">
 This controls where the cover photo should be displayed.
 
 It defaults to the <Show />, <Edit />, and <New /> views, but you can change that to be displayed to the <Index /> view or a combination of views.
@@ -140,9 +140,9 @@ It defaults to the <Show />, <Edit />, and <New /> views, but you can change tha
 You may choose one view or a combination of them using an array.
 
 `:show`, `:edit`, `:new`, `:index`, `:forms`, `:display`, `[:show, :edit]`;
-:::
+</Option>
 
-:::option `source`
+<Option name="`source`">
 This controls what should be displayed as the image.
 
 You can call a field on the record using a `Symbol`, or you can open a block where you have access to the `record` and add your own value.
@@ -176,4 +176,4 @@ self.cover_photo = {
   }
 }
 ```
-:::
+</Option>

--- a/docs/3.0/custom-fields.md
+++ b/docs/3.0/custom-fields.md
@@ -80,7 +80,7 @@ The generated view components are basic text fields for now.
 
 You can customize them and add as much or as little content as needed. More on customization [below](#customize-the-views).
 
-:::option Use existent field template
+<Option name="Use existent field template">
 There may be times when you want to duplicate an existing field and start from there.
 
 To achieve this behavior, use the `--field_template` argument and pass the original field as a value.
@@ -140,7 +140,7 @@ module Avo
   end
 end
 ```
-:::
+</Option>
 ## Field options
 
 This file is where you may add field-specific options.

--- a/docs/3.0/customizable-controls.md
+++ b/docs/3.0/customizable-controls.md
@@ -18,7 +18,7 @@ By default, Avo displays a few buttons (controls) for the user to use on the <In
 
 You can take over and customize them all using the `index_controls`, `show_controls`, `edit_controls`, and `row_controls` class attributes.
 
-:::option Show page
+<Option name="Show page">
 On the <Show /> view the default configuration is `back_button`, `delete_button`, `detach_button`, `actions_list`, and `edit_button`.
 
 To start customizing the controls, add a `show_controls` block and start adding the desired controls.
@@ -43,9 +43,9 @@ end
 ```
 
 <Image src="/assets/img/3_0/customizable-controls/show-controls.png" width="1344" height="164" alt="" />
-:::
+</Option>
 
-:::option Edit page
+<Option name="Edit page">
 On the <Edit /> view the default configuration is `back_button`, `delete_button`, `actions_list`, and `save_button`.
 
 To start customizing the controls, add a `edit_controls` block and start adding the desired controls.
@@ -65,9 +65,9 @@ end
 ```
 
 <Image src="/assets/img/3_0/customizable-controls/show-controls.png" width="1344" height="164" alt="" />
-:::
+</Option>
 
-:::option Index page
+<Option name="Index page">
 On the <Index /> view the default configuration contains the `actions_list`, `attach_button`, and `create_button`.
 
 To start customizing the controls, add a `index_controls` block and start adding the desired controls.
@@ -85,9 +85,9 @@ end
 ```
 
 <Image src="/assets/img/3_0/customizable-controls/index-controls.png" width="1300" height="164" alt="" />
-:::
+</Option>
 
-:::option Row controls
+<Option name="Row controls">
 On the <Index /> view the on the end of each table row the default configuration contains the `order_controls` `show_button`, `edit_button`, `detach_button`, and `delete_button`.
 
 To start customizing the controls, add a `row_controls` block and start adding the desired controls.
@@ -111,7 +111,7 @@ end
 ```
 
 <Image src="/assets/img/3_0/customizable-controls/row-controls.png" width="834" height="120" alt="" />
-:::
+</Option>
 
 ## Controls
 
@@ -119,31 +119,31 @@ A control is an item that you can place in a designated area. They can be one of
 
 You may use the following controls:
 
-:::option `back_button`
+<Option name="`back_button`">
 Links to a previous page. The link is not a `history.back()` action. It's computed based on the parameters sent by Avo. That ensures the user has consistent hierarchical progress through the app.
 
 #### Supported options
 
 `label`, `title`, `style`, `color`, and `icon`.
-:::
+</Option>
 
-:::option `delete_button`
+<Option name="`delete_button`">
 Adds the appropriate destroy form. It will take into account your authorization policy rules.
 
 #### Supported options
 
 `label`, `title`, `style`, `color`, and `icon`.
-:::
+</Option>
 
-:::option `detach_button`
+<Option name="`detach_button`">
 Adds the appropriate detach form. It's visible only on the association (`has_one`) page. It will take into account your authorization policy rules.
 
 #### Supported options
 
 `label`, `title`, `style`, `color`, and `icon`.
-:::
+</Option>
 
-:::option `actions_list`
+<Option name="`actions_list`">
 A dropdown where the user can see and run all the actions assigned to that resource.
 
 #### Supported options
@@ -166,24 +166,25 @@ actions_list exclude: [ExportSelection, PublishPost]
 :::info
 The list action's [icon](actions.md#icon) and the [dividers](actions.md#divider) are defined in `def actions` method.
 :::
+</Option>
 
-:::option `edit_button`
+<Option name="`edit_button`">
 Links to the record edit page.
 
 #### Supported options
 
 `label`, `title`, `style`, `color`, and `icon`.
-:::
+</Option>
 
-:::option `link_to`
+<Option name="`link_to`">
 Renders a link to a path set by you.
 
 #### Supported options
 
 `title`, `style`, `color`, `icon`, `target`, `data`, and `class`.
-:::
+</Option>
 
-:::option `action`
+<Option name="`action`">
 Renders a button that triggers an action. You must provide it an [Action](./actions) class.
 
 #### Supported options
@@ -199,7 +200,7 @@ action Avo::Actions::ExportSelection, style: :text
 action Avo::Actions::PublishPost, color: :fuchsia, icon: "heroicons/outline/eye"
 ```
 
-:::
+</Option>
 
 :::warning WARNING (**NOT** applicable for versions greater than <Version version="3.10.7" />)
 
@@ -228,7 +229,7 @@ end
 ```
 :::
 
-:::option `default_controls`
+<Option name="`default_controls`">
 There are times when you just want to add a link before or after the default controls and don't want to re-add them all.
 Avo's got you covered! `default_controls` to the rescue.
 
@@ -241,60 +242,60 @@ end
 ```
 
 <Image src="/assets/img/3_0/customizable-controls/default_controls.png" alt="Default controls" width="884" height="140" />
-:::
+</Option>
 
 ## Control Options
 
 Some controls take options. Not all controls take all options.
 Example: The `link_to` control is the only one that will take the `target` option, but most other controls use the `class` option.
 
-:::option `title`
+<Option name="`title`">
 Sets the tooltip for that control.
 
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `style`
+<Option name="`style`">
 Sets the `style` attribute for the [`Avo::ButtonComponent`](https://github.com/avo-hq/avo/blob/main/app/components/avo/button_component.rb).
 
 #### Possible values
 
 `:primary`, `:outline`, `:text`
-:::
+</Option>
 
-:::option `color`
+<Option name="`color`">
 Sets the `color` attribute for the [`Avo::ButtonComponent`](https://github.com/avo-hq/avo/blob/main/app/components/avo/button_component.rb)
 
 #### Possible values
 
 Can be any color of [Tailwind`s default color pallete](https://tailwindcss.com/docs/customizing-colors#default-color-palette) as a symbol.
-:::
+</Option>
 
-:::option `icon`
+<Option name="`icon`">
 Sets the icon for that button.
 
 #### Possible values
 
 Any [Heroicon](https://heroicons.com) you want. You must specify the style of the heroicon like so `heoricons/outline/academic-cap` or `heroicons/solid/adjustments`.
-:::
+</Option>
 
-:::option `target`
+<Option name="`target`">
 Sets the target for that control. So whatever you pass here will be passed to the control.
 
 #### Possible values
 
 `:_blank`, `:_top`, `:_self`
-:::
+</Option>
 
-:::option `class`
+<Option name="`class`">
 Sets the classes for that control.
 
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
 ## Default values
 

--- a/docs/3.0/customization.md
+++ b/docs/3.0/customization.md
@@ -108,10 +108,6 @@ Using `full_width_container: true` tells Avo to display all views full-width.
 
 ## Cache resources on the `Index` view
 
-<!-- :::info
-  Since version <Version version="2.30" /> `cache_resources_on_index_view` is disabled by default.
-::: -->
-
 Avo caches each resource row (or Grid item for Grid view) for performance reasons. You can disable that cache using the `cache_resources_on_index_view` configuration option. The cache key is using the record's `id` and `created_at` attributes and the resource file `md5`.
 
 :::info
@@ -468,7 +464,7 @@ config.logger = -> {
 }
 ```
 
-::::option `default_url_options`
+<Option name="`default_url_options`">
 `default_url_options` is a Rails [controller method](https://apidock.com/rails/ActionController/Base/default_url_options) that will append params automatically to the paths you generate through path helpers.
 
 In order to implement some features like route-level Multitenancy we exposed an API to add to Avo's `default_url_options` method.
@@ -487,11 +483,12 @@ Rails.application.routes.draw do
   end
 end
 ```
+:::
 
 Now, when you visit `https://example.org/account/adrian/avo`, the `account_id` param is `adrian` and it will be appended to all path helpers.
-::::
+</Option>
 
-:::option `turbo`
+<Option name="`turbo`">
 You may want to configure how turbo behave on Avo.
 
 You can configure it using `config.turbo` option on `avo.rb` initializer
@@ -505,9 +502,9 @@ Supported options with default values:
     }
   end
 ```
-:::
+</Option>
 
-:::option `pagination`
+<Option name="`pagination`">
 You can configure the default pagination settings key by key.
 
 ```ruby
@@ -527,9 +524,9 @@ end
 This will make all your application's tables countless keeping the size key / value as the default one.
 
 Verify all possible options [here](resources#self_pagination).
-:::
+</Option>
 
-::::option `click_row_to_view_record`
+<Option name="`click_row_to_view_record`">
 
 <!-- <BetaStatus status="beta" /> -->
 
@@ -551,4 +548,4 @@ end
 ```
 
 <Image src="/assets/img/3_0/customization/click-row-to-view-record.gif" width="" height="" alt="Click to view record in Avo" />
-::::
+</Option>

--- a/docs/3.0/dynamic-filters.md
+++ b/docs/3.0/dynamic-filters.md
@@ -61,7 +61,7 @@ Avo uses the input value and the specified condition to build a Ransack query. T
 
 For instance, in the text filter example above, the `Contains` condition and the input value `John` are translated into a Ransack query resulting into the SQL `LIKE` operator to find all records where the name contains `John`.
 
-:::option Boolean
+<Option name="Boolean">
 
 ### Conditions
 
@@ -75,9 +75,9 @@ For instance, in the text filter example above, the `Contains` condition and the
 </div>
 
 Test it on [avodemo](https://main.avodemo.com/avo/resources/users?filters[is_admin?][is_true][]=), check the [source code](https://github.com/avo-hq/main.avodemo.com/blob/main/app/avo/resources/user.rb#L38)
-:::
+</Option>
 
-:::option Date
+<Option name="Date">
 
 ### Conditions
 
@@ -95,9 +95,9 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/users?filters[is_adm
 </div>
 
 Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[created_at][lte][]=2024-07-02%2012%3A00), check the [source code](https://github.com/avo-hq/main.avodemo.com/blob/main/app/avo/resources/team.rb#L50)
-:::
+</Option>
 
-:::option Has many
+<Option name="Has many">
 
 This filter will give you options from the database.
 
@@ -119,9 +119,9 @@ This filter will give you options from the database.
 </div>
 
 Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[memberships][contains][]=), check the [source code](https://github.com/avo-hq/main.avodemo.com/blob/main/app/avo/resources/team.rb#L75)
-:::
+</Option>
 
-:::option Number
+<Option name="Number">
 
 ### Conditions
 
@@ -138,9 +138,9 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[member
 </div>
 
 Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[id][gte][]=2), check the [source code](https://github.com/avo-hq/main.avodemo.com/blob/main/app/avo/resources/team.rb#L27)
-:::
+</Option>
 
-:::option Select
+<Option name="Select">
 
 ### Conditions
 
@@ -155,9 +155,9 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[id][gt
 </div>
 
 Test it on [avodemo](https://main.avodemo.com/avo/resources/courses?filters[country][is][]=USA), check the [source code](https://github.com/avo-hq/main.avodemo.com/blob/main/app/avo/resources/course.rb#L55)
-:::
+</Option>
 
-:::option Text
+<Option name="Text">
 
 ### Conditions
 
@@ -178,8 +178,8 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/courses?filters[coun
 </div>
 
 Test it on [avodemo](https://main.avodemo.com/avo/resources/users?filters[first_name][contains][]=Avo), check the [source code](https://github.com/avo-hq/main.avodemo.com/blob/main/app/avo/resources/user.rb#L33)
-:::
-::::option Tags
+</Option>
+<Option name="Tags">
 
 ### Conditions
 
@@ -204,7 +204,7 @@ The source code uses custom dynamic filters DSL available <VersionReq version="3
 Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
 :::
 
-::::
+</Option>
 
 ## Options
 
@@ -223,13 +223,13 @@ if defined?(Avo::DynamicFilters)
 end
 ```
 
-:::option `button_label`
+<Option name="`button_label`">
 This will change the label on the expand label.
-:::
+</Option>
 
-:::option `always_expanded`
+<Option name="`always_expanded`">
 You may opt-in to have them always expanded and have the button hidden.
-:::
+</Option>
 
 ## Field to filter matching
 On versions **lower** than <Version version="3.10.0" /> the filters are not configurable so each field will have a dedicated filter type. Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
@@ -298,7 +298,7 @@ Each option specified below can be used as a key in the hash definition or as a 
 :::info Filters order
 The filter order is computed. Dynamic filters defined by the `dynamic_filter` method will respect the definition order and will be rendered first in the filter list. Filters declared using the field's `filterable` option will be sorted by label.
 :::
-:::option `label`
+<Option name="`label`">
 
 Customize filter's label
 
@@ -309,10 +309,10 @@ Field's / filter's ID humanized.
 #### Possible values
 
 Any string
-:::
+</Option>
 
 
-:::option `icon`
+<Option name="`icon`">
 
 Customize filter's icon. Check [icons documentation](./icons)
 
@@ -330,9 +330,9 @@ Text filter - `avo/font`<br>
 #### Possible values
 
 Any icon from [avo](https://github.com/avo-hq/avo/tree/feature/allow_actions_to_render_turbo_streams/app/assets/svgs/avo) or [heroicons](https://heroicons.com/).
-:::
+</Option>
 
-:::option `type`
+<Option name="`type`">
 
 Customize filter's type
 
@@ -350,9 +350,9 @@ Computed from field using [`field_to_filter` method](#field-to-filter-matching).
 - [`:text`](#text)<br>
 - [`:tags`](#tags)<br>
 - `:array`<br>
-:::
+</Option>
 
-:::option `query`
+<Option name="`query`">
 
 Customize filter's query
 
@@ -398,9 +398,9 @@ dynamic_filter :first_name,
     end
   }
 ```
-:::
+</Option>
 
-:::option `conditions`
+<Option name="`conditions`">
 
 Customize filter's conditions
 
@@ -433,9 +433,9 @@ dynamic_filter :first_name,
     not_case_sensitive: "Not case sensitive"
   }.invert
 ```
-:::
+</Option>
 
-:::option `query_attributes`
+<Option name="`query_attributes`">
 
 Customize filter's query attributes
 
@@ -482,9 +482,9 @@ dynamic_filter label: "User (email & first_name)",
 ```
 
 This is possible due to a Ransack feature. To use it, you need to add the association name before the attribute.
-:::
+</Option>
 
-:::option `suggestions`
+<Option name="`suggestions`">
 Suggestions work on filters that provide text input, enhancing the user experience by offering relevant options. This functionality is especially useful in scenarios where users might need guidance or where the filter values are numerous or complex.
 
 ##### Default value
@@ -524,4 +524,4 @@ field :first_name,
 dynamic_filter :first_name,
   suggestions: -> { ["Avo", "Cado", params[:extra_suggestion]] }
 ```
-:::
+</Option>

--- a/docs/3.0/eject-views.md
+++ b/docs/3.0/eject-views.md
@@ -6,7 +6,7 @@ If you want to change one of Avo's built-in views, you can eject it, update it a
 Once ejected, the views will not receive updates on new Avo releases. You must maintain them yourself.
 :::
 
-:::option `--partial`
+<Option name="`--partial`">
 Utilize the `--partial` option when you intend to extract certain partial
 
 ## Prepared templates
@@ -54,9 +54,9 @@ You can eject any partial from Avo using the partial path.
 ▶ bin/rails generate avo:eject --partial app/views/layouts/avo/application.html.erb
       create  app/views/layouts/avo/application.html.erb
 ```
-:::
+</Option>
 
-:::option `--component`
+<Option name="`--component`">
 You can eject any view component from Avo using the `--component` option.
 
 ```bash
@@ -73,9 +73,9 @@ Have the same output:
 create  app/components/avo/index/table_row_component.rb
 create  app/components/avo/index/table_row_component.html.erb
 ```
-:::
+</Option>
 
-:::option `--field-components`
+<Option name="`--field-components`">
 With `--field-components` option is easy to eject, one or multiple field components. Notice that without using the `--scope`, the ejected components will override the original components for that field everywhere on the project.
 
 Check the `--scope` and the [`components`](./field-options.html#components) field options for more details on how to override the components only on specific parts of the project.
@@ -99,12 +99,16 @@ $ rails g avo:eject --field-components text --view edit
       create  app/components/avo/fields/text_field/edit_component.html.erb
 ```
 
-:::option `--view`
+</Option>
+
+<Option name="`--view`">
+
 While utilizing the `--field-components` option, you can selectively extract a specific view using the `--view` parameter, as demonstrated in the example above. If this option is omitted, all components of the field will be ejected.
-:::
+
+</Option>
 
 
-:::option `--scope`
+<Option name="`--scope`">
 When you opt to eject a view component that exists under `Avo::Views` or a field component under `Avo::Fields` namespace, for example the `Avo::Views::ResourceIndexComponent` or `Avo::Fields::TextField::ShowComponent` you can employ the `--scope` option to specify the namespace that should be adopted by the ejected component, extending from `Avo::Views` / `Avo::Fields`.
 
 ```bash
@@ -128,5 +132,5 @@ class Avo::Fields::Admins::TextField::ShowComponent < Avo::Fields::ShowComponent
 :::info Scopes transformation
 `--scope users_admins` -> `Avo::Views::UsersAdmins::ResourceIndexComponent`<br>
 `--scope users/admins` -> `Avo::Views::Users::Admins::ResourceIndexComponent`
-
 :::
+</Option>

--- a/docs/3.0/encryption-service.md
+++ b/docs/3.0/encryption-service.md
@@ -10,25 +10,25 @@ The `EncryptionService` is an service that can be called anywhere on the app.
 
 ### Public methods
 
-:::option `encrypt`
+<Option name="`encrypt`">
 Used to encrypt data
-:::
+</Option>
 
-:::option `decrypt`
+<Option name="`decrypt`">
 Used to decrypt data
-:::
+</Option>
 
 <br><br>
 
 ### Mandatory arguments:
 
-:::option `message`
+<Option name="`message`">
 Object to be encrypted
-:::
+</Option>
 
-:::option `purpose`
+<Option name="`purpose`">
 A symbol with the purpose of encryption, can be anything, it just ***need to match when decrypting***.
-:::
+</Option>
 
 <br><br>
 

--- a/docs/3.0/execution-context.md
+++ b/docs/3.0/execution-context.md
@@ -60,40 +60,40 @@ Avo::ExecutionContext.new(target: &SOME_BLOCK, record: User.first).handle
 
 This means you could throw any type of object at it and it it responds to a `call` method wil will be called with all those objects.
 
-:::option `target`
+<Option name="`target`">
 The block you'll pass to be evaluated. It may be anything but will only be evaluated if it responds to a `call` method.
-:::
+</Option>
 
-:::option `context`
+<Option name="`context`">
 Aliased to [`Avo::Current.context`](./avo-current#context).
-:::
+</Option>
 
-:::option `current_user`
+<Option name="`current_user`">
 Aliased to [`Avo::Current.user`](./avo-current#user).
-:::
+</Option>
 
-:::option `view_context`
+<Option name="`view_context`">
 Aliased to [`Avo::Current.view_context`](./avo-current#view_context).
-:::
+</Option>
 
-:::option `request`
+<Option name="`request`">
 Aliased to [`Avo::Current.request`](./avo-current#request).
-:::
+</Option>
 
-:::option `params`
+<Option name="`params`">
 Aliased to [`Avo::Current.params`](./avo-current#params).
-:::
+</Option>
 
-:::option Custom variables
+<Option name="Custom variables">
 You can pass any variable to the `ExecutionContext` and it will be available in that block.
 This is how we can expose `view`, `record`, and `resource` in the computed field example.
 
 ```ruby
 Avo::ExecutionContext.new(target: &SOME_BLOCK, record: User.first, view: :index, resource: resource).handle
 ```
-:::
+</Option>
 
-:::option `helpers`
+<Option name="`helpers`">
 Within the `ExecutionContext` you might want to use some of your already defined helpers. You can do that using the `helpers` object.
 
 ```ruby
@@ -106,4 +106,5 @@ class ProductsHelper
 end
 
 field :name, as: :text, format_using: -> { helpers.simple_name(value) }
-:::
+```
+</Option>

--- a/docs/3.0/field-options.md
+++ b/docs/3.0/field-options.md
@@ -384,12 +384,12 @@ Now, all fields will have the stacked layout throughout your app.
 
 ## Field options
 
-:::option `use_resource`
+<Option name="`use_resource`">
 <!-- TODO: this -->
 WIP
-:::
+</Option>
 
-:::option `components`
+<Option name="`components`">
 The field's `components` option allows you to customize the view components used for rendering the field in all, `index`, `show` and `edit` views. This provides you with a high degree of flexibility.
 
 ### Ejecting the field components
@@ -446,7 +446,7 @@ The components block it's executed using `Avo::ExecutionContent` and gives acces
 It's important to keep the initializer on your custom components as the original field view component initializer.
 :::
 
-:::option `html`
+<Option name="`html`">
 ### Attach HTML attributes
 
 Using the `html` option you can attach `style`, `classes`, and `data` attributes. The `style` attribute adds the `style` tag to your element, `classes` adds the `class` tag, and the `data` attribute the `data` tag to the element you choose.
@@ -467,6 +467,7 @@ field :name, as: :text, html: {
   }
 }
 ```
+</Option>
 
 #### Declare the fields from the outside in
 
@@ -639,9 +640,9 @@ field :name, as: :text, html: {
 
 <Image src="/assets/img/stimulus/edit-input-target.jpg" width="1646" height="784" alt="Index field wrapper" />
 
-:::
+</Option>
 
-:::option `summarizable`
+<Option name="`summarizable`">
 
 ```ruby
 field :status, as: :select, summarizable: true
@@ -649,9 +650,9 @@ field :status, as: :select, summarizable: true
 field :status, as: :badge, summarizable: true
 ```
 This section is WIP.
-:::
+</Option>
 
-:::option `for_attribute`
+<Option name="`for_attribute`">
 
 Allows to specify the target attribute on the model for each field. By default the target attribute is the field's id.
 
@@ -669,9 +670,9 @@ field :secondary_field_for_status,
   except_on: :forms,
   help: "Secondary field for status using the for_attribute option"
 ```
-:::
+</Option>
 
-:::option `meta`
+<Option name="`meta`">
 
 This handy option enables you to send arbitrary information to the field. It's especially useful when you're building your own [custom fields](./custom-fields) or you are using [custom components](#components) for the built-in fields.
 
@@ -704,4 +705,4 @@ Within your field template you can now access the `@field.meta` attribute.
   <% end %>
 <% end %>
 ```
-:::
+</Option>

--- a/docs/3.0/field-wrappers.md
+++ b/docs/3.0/field-wrappers.md
@@ -19,7 +19,7 @@ Each field displayed on the <Index /> view is wrapped in this component that reg
 
 You may use the component `Avo::Index::FieldWrapperComponent` or the helper `index_field_wrapper`.
 
-:::option `dash_if_blank`
+<Option name="`dash_if_blank`">
 This option renders a dash `—` if the content inside responds to true on the `blank?` method.
 In the example below, we'd like to show the field as a red checkmark even if the content is `nil`.
 
@@ -32,9 +32,9 @@ In the example below, we'd like to show the field as a red checkmark even if the
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `center_content`
+<Option name="`center_content`">
 Wraps the content in a container with `flex items-center justify-center` classes making everything centered horizontally and vertically.
 
 #### Default
@@ -46,9 +46,9 @@ Wraps the content in a container with `flex items-center justify-center` classes
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `flush`
+<Option name="`flush`">
 Removes the padding around the field allowing it to flow from edge to edge.
 
 #### Default
@@ -60,9 +60,9 @@ Removes the padding around the field allowing it to flow from edge to edge.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `field`
+<Option name="`field`">
 The instance of the field. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -70,9 +70,9 @@ The instance of the field. It's usually passed in with the `field_wrapper_args`.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `resource`
+<Option name="`resource`">
 The instance of the resource. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -80,7 +80,7 @@ The instance of the resource. It's usually passed in with the `field_wrapper_arg
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
 # Show & Edit field wrapper
 
@@ -113,7 +113,7 @@ This space is rarely used and it's there just to fill some horizontal space so t
 
 ## Options
 
-:::option `dash_if_blank`
+<Option name="`dash_if_blank`">
 This option renders a dash `—` if the content inside responds to true on the `blank?` method.
 In the example below, we'd like to show the field as a red checkmark even if the content is `nil`.
 
@@ -126,9 +126,9 @@ In the example below, we'd like to show the field as a red checkmark even if the
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `compact`
+<Option name="`compact`">
 This renders the field in a more compact way by removing the **Extra** area and decresing the width of the **Label** and **Content** areas.
 
 This is enabled on the fields displayed in actions.
@@ -142,9 +142,9 @@ This is enabled on the fields displayed in actions.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `data`
+<Option name="`data`">
 Pass in some data attributes. Perhaps you would like to attach a StimulusJS controller to this field.
 
 ```erb
@@ -152,9 +152,9 @@ Pass in some data attributes. Perhaps you would like to attach a StimulusJS cont
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `full_width`
+<Option name="`full_width`">
 This removes the **Extra** area and renders the **Value** area full width.
 
 This is used on fields that require a larger area to be displayed like [WYSIWYG editors](./fields/trix), [`KeyValue`](./fields/key_value), or [file fields](./fields/files).
@@ -168,9 +168,9 @@ This is used on fields that require a larger area to be displayed like [WYSIWYG 
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `form`
+<Option name="`form`">
 The instance of the form that is going to be populated. It's usually passed in with the `field_wrapper_args` on the <Edit /> view.
 
 ```erb
@@ -178,9 +178,9 @@ The instance of the form that is going to be populated. It's usually passed in w
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `field`
+<Option name="`field`">
 The instance of the field. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -188,9 +188,9 @@ The instance of the field. It's usually passed in with the `field_wrapper_args`.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `help`
+<Option name="`help`">
 The text that is going to be displayed below the actual field on the <Edit /> view.
 
 ```erb
@@ -198,9 +198,9 @@ The text that is going to be displayed below the actual field on the <Edit /> vi
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `label`
+<Option name="`label`">
 The text that is going to be displayed in the **Label** area. You might want to override it.
 
 ```erb
@@ -208,9 +208,9 @@ The text that is going to be displayed in the **Label** area. You might want to 
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `resource`
+<Option name="`resource`">
 The instance of the resource. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -218,9 +218,9 @@ The instance of the resource. It's usually passed in with the `field_wrapper_arg
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `stacked`
+<Option name="`stacked`">
 Display the field in a column layout with the label on top of the value
 
 ```erb
@@ -228,12 +228,12 @@ Display the field in a column layout with the label on top of the value
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
 <Image src="/assets/img/field-wrappers/stacked_field.jpg" width="1024" height="639" alt="" />
 
 
-:::option `style`
+<Option name="`style`">
 The you might want to pass some styles to the wrapper to change it's looks.
 
 ```erb
@@ -241,9 +241,9 @@ The you might want to pass some styles to the wrapper to change it's looks.
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `view`
+<Option name="`view`">
 The view where the field is diplayed so it knows if it's a <Show /> or <Edit /> view. It's usually passed in with the `field_wrapper_args`.
 
 ```erb
@@ -251,5 +251,5 @@ The view where the field is diplayed so it knows if it's a <Show /> or <Edit /> 
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
-:::
+</Option>
 

--- a/docs/3.0/fields/badge.md
+++ b/docs/3.0/fields/badge.md
@@ -32,7 +32,7 @@ The `Badge` field is intended to be displayed only on **Index** and **Show** vie
 
 ## Options
 
-:::option `options`
+<Option name="`options`">
 
 The options should be a hash with the keys of one of the five available types (`info`, `success`, `warning`, `danger`, `neutral`) and the values matching your record's database values.
 
@@ -41,7 +41,7 @@ The options should be a hash with the keys of one of the five available types (`
 `{ info: :info, success: :success, danger: :danger, warning: :warning, neutral: :neutral }`
 
 Below is an example of how you can use two fields in that combination.
-:::
+</Option>
 
 ## Examples
 

--- a/docs/3.0/fields/boolean.md
+++ b/docs/3.0/fields/boolean.md
@@ -19,7 +19,7 @@ field :is_published,
 
 ## Options
 
-:::option `true_value`
+<Option name="`true_value`">
 
 What should count as true. You can use `1`, `yes`, or a different value.
 
@@ -27,12 +27,12 @@ What should count as true. You can use `1`, `yes`, or a different value.
 
 `[true, "true", "1"]`
 
-:::
-:::option `false_value`
+</Option>
+<Option name="`false_value`">
 
 What should count as false. You can use `0`, `no`, or a different value.
 
 #### Default value
 
 `[false, "false", "0"]`
-:::
+</Option>

--- a/docs/3.0/fields/boolean_group.md
+++ b/docs/3.0/fields/boolean_group.md
@@ -38,7 +38,7 @@ field :roles,
 
 
 
-:::option `options`
+<Option name="`options`">
 The `options` attribute should be a `Hash` where the keys match the DB keys and the values are the visible labels.
 
 #### Default value
@@ -68,7 +68,7 @@ end
 
 The output value must be a hash as described above.
 
-:::
+</Option>
 
 
 ## Updates

--- a/docs/3.0/fields/code.md
+++ b/docs/3.0/fields/code.md
@@ -15,7 +15,7 @@ field :custom_css, as: :code, theme: 'dracula', language: 'css'
 
 ## Options
 
-:::option `theme`
+<Option name="`theme`">
 
 Customize the color theme.
 
@@ -28,9 +28,9 @@ Customize the color theme.
 `material-darker`, `eclipse`, or `dracula`
 
 Preview the themes here: [codemirror-themes](https://codemirror.net/demo/theme.html).
-:::
+</Option>
 
-:::option `language`
+<Option name="`language`">
 Customize the syntax highlighting using the language method.
 
 #### Default value
@@ -40,9 +40,9 @@ Customize the syntax highlighting using the language method.
 #### Possible values
 
 `css`, `dockerfile`, `htmlmixed`, `javascript`, `markdown`, `nginx`, `php`, `ruby`, `sass`, `shell`, `sql`, `vue` or `xml`.
-:::
+</Option>
 
-:::option `height`
+<Option name="`height`">
 Customize the height of the editor.
 
 #### Default value
@@ -52,9 +52,9 @@ Customize the height of the editor.
 #### Possible values
 
 `auto`, or any value in pixels (eg `height: 250px`).
-:::
+</Option>
 
-:::option `tab_size`
+<Option name="`tab_size`">
 Customize the tab_size of the editor.
 
 #### Default value
@@ -64,9 +64,9 @@ Customize the tab_size of the editor.
 #### Possible values
 
 Any integer value.
-:::
+</Option>
 
-:::option `indent_with_tabs`
+<Option name="`indent_with_tabs`">
 Customize the type of indentation.
 
 #### Default value
@@ -76,9 +76,9 @@ Customize the type of indentation.
 #### Possible values
 
 `true` or `false`
-:::
+</Option>
 
-:::option `line_wrapping`
+<Option name="`line_wrapping`">
 Customize whether the editor should apply line wrapping.
 
 #### Default value
@@ -88,4 +88,4 @@ Customize whether the editor should apply line wrapping.
 #### Possible values
 
 `true` or `false`
-:::
+</Option>

--- a/docs/3.0/fields/country.md
+++ b/docs/3.0/fields/country.md
@@ -22,7 +22,7 @@ field :country, as: :country, display_code: true
 
 ## Options
 
-:::option `display_code`
+<Option name="`display_code`">
 
 You can easily choose to display the `code` of the country on **Index** and **Show** views by declaring `display_code` to `true`.
 
@@ -33,4 +33,4 @@ You can easily choose to display the `code` of the country on **Index** and **Sh
 ### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/3.0/fields/date.md
+++ b/docs/3.0/fields/date.md
@@ -18,7 +18,7 @@ field :birthday,
 
 ## Options
 
-:::option `format`
+<Option name="`format`">
 Format the date shown to the user on the `Index` and `Show` views.
 
 #### Default
@@ -28,8 +28,8 @@ Format the date shown to the user on the `Index` and `Show` views.
 #### Possible values
 
 Use [`luxon`](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) formatting tokens.
-:::
-:::option `picker_format`
+</Option>
+<Option name="`picker_format`">
 Format the date shown to the user on the `Edit` and `New` views.
 
 #### Default
@@ -39,9 +39,9 @@ Format the date shown to the user on the `Edit` and `New` views.
 #### Possible values
 
 Use [`flatpickr`](https://flatpickr.js.org/formatting) formatting tokens.
-:::
+</Option>
 
-:::option `picker_options`;
+<Option name="`picker_options`;">
 Passes the options here to [flatpickr](https://flatpickr.js.org/).
 
 #### Default
@@ -56,5 +56,5 @@ Use [`flatpickr`](https://flatpickr.js.org/options) options.
 These options may override other options like `picker_options`.
 :::
 
-::::
+</Option>
 <!-- @include: ./../common/date_date_time_common.md-->

--- a/docs/3.0/fields/date_time.md
+++ b/docs/3.0/fields/date_time.md
@@ -21,7 +21,7 @@ field :joined_at,
 
 ## Options
 
-:::option `format`
+<Option name="`format`">
 
 Format the date shown to the user on the `Index` and `Show` views.
 
@@ -32,8 +32,8 @@ Format the date shown to the user on the `Index` and `Show` views.
 #### Possible values
 
 Use [`luxon`](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) formatting tokens.
-:::
-:::option `picker_format`
+</Option>
+<Option name="`picker_format`">
 Format the date shown to the user on the `Edit` and `New` views.
 
 #### Default
@@ -43,13 +43,13 @@ Format the date shown to the user on the `Edit` and `New` views.
 #### Possible values
 
 Use [`flatpickr`](https://flatpickr.js.org/formatting) formatting tokens.
-:::
-:::option `time_24hr`
+</Option>
+<Option name="`time_24hr`">
 Displays time picker in 24-hour mode or AM/PM selection.
 
 <!-- @include: ./../common/default_boolean_false.md -->
-:::
-:::option `timezone`
+</Option>
+<Option name="`timezone`">
 Select in which timezone the values should be cast.
 
 #### Default
@@ -65,9 +65,9 @@ field :started_at, as: :date_time, timezone: "EET"
 # Or
 field :started_at, as: :date_time, timezone: -> { record.timezone }
 ```
-:::
+</Option>
 
-:::option `picker_options`
+<Option name="`picker_options`">
 Passes the options here to [flatpickr](https://flatpickr.js.org/).
 
 #### Default
@@ -77,7 +77,7 @@ Passes the options here to [flatpickr](https://flatpickr.js.org/).
 #### Possible values
 
 Use [`flatpickr`](https://flatpickr.js.org/options) options.
-:::
+</Option>
 
 :::warning
 These options may override other options like `time_24hr`.

--- a/docs/3.0/fields/external_image.md
+++ b/docs/3.0/fields/external_image.md
@@ -15,7 +15,7 @@ field :logo, as: :external_image
 
 ## Options
 
-:::option `width`
+<Option name="`width`">
 
 #### Default value
 
@@ -24,9 +24,9 @@ field :logo, as: :external_image
 #### Possible values
 
 Use any number to size the image.
-:::
+</Option>
 
-:::option `height`
+<Option name="`height`">
 #### Default value
 
 `40`
@@ -34,9 +34,9 @@ Use any number to size the image.
 #### Possible values
 
 Use any number to size the image.
-:::
+</Option>
 
-:::option `radius`
+<Option name="`radius`">
 #### Default value
 
 `0`
@@ -44,7 +44,7 @@ Use any number to size the image.
 #### Possible values
 
 Use any number to set the radius value.
-:::
+</Option>
 
 <!-- @include: ./../common/link_to_record_common.md-->
 

--- a/docs/3.0/fields/files.md
+++ b/docs/3.0/fields/files.md
@@ -18,7 +18,7 @@ field :documents, as: :files
 
 <!-- @include: ./../common/file_other_common.md-->
 
-:::option `view_type`
+<Option name="`view_type`">
 <Image src="/assets/img/files_view_types.gif" width="1734" height="431" alt="" />
 
 Set the default `view_type`.
@@ -30,9 +30,9 @@ Set the default `view_type`.
 #### Possible values
 
 `grid`, `list`
-:::
+</Option>
 
-:::option `hide_view_type_switcher`
+<Option name="`hide_view_type_switcher`">
 Option to hide the view type switcher component.
 
 #### Default
@@ -42,4 +42,4 @@ Option to hide the view type switcher component.
 #### Possible values
 
 `true`, `false`
-:::
+</Option>

--- a/docs/3.0/fields/gravatar.md
+++ b/docs/3.0/fields/gravatar.md
@@ -16,15 +16,15 @@ field :email,
 ```
 
 ## Options
-:::option `rounded`
+<Option name="`rounded`">
 Choose whether the rendered avatar should be rounded or not on the `Index` view.
 
 On `Show`, the image is always a `square,` and the size is `responsive`.
 
 <!-- @include: ./../common/default_boolean_true.md -->
-:::
+</Option>
 
-:::option `size`
+<Option name="`size`">
 Set the size of the avatar.
 
 #### Default
@@ -34,9 +34,9 @@ Set the size of the avatar.
 #### Possible values
 
 Any number in pixels. Remember that the size will influence the `Index` table row height.
-:::
+</Option>
 
-:::option `default`
+<Option name="`default`">
 Set the default image if the email address was not found in Gravatar's database.
 
 #### Default
@@ -46,7 +46,7 @@ Set the default image if the email address was not found in Gravatar's database.
 #### Possible values
 
 Any number in pixels. Remember that the size will influence the `Index` table row height.
-:::
+</Option>
 
 <!-- @include: ./../common/link_to_record_common.md-->
 

--- a/docs/3.0/fields/heading.md
+++ b/docs/3.0/fields/heading.md
@@ -34,7 +34,7 @@ The computed fields are not rendered on form views, same with heading field, if 
 
 ## Options
 
-:::option `as_html`
+<Option name="`as_html`">
 The `as_html` option will render it as HTML.
 
 ```ruby
@@ -44,12 +44,12 @@ end
 ```
 
 <!-- @include: ./../common/default_boolean_false.md -->
-:::
+</Option>
 
-:::option `label`
+<Option name="`label`">
 The content of `label` is the content displayed on the heading space.
 
 ```ruby
 field :some_id, as: :heading, label: "user information"
 ```
-:::
+</Option>

--- a/docs/3.0/fields/key_value.md
+++ b/docs/3.0/fields/key_value.md
@@ -15,7 +15,7 @@ field :meta, as: :key_value
 
 ## Options
 
-:::option `key_label`
+<Option name="`key_label`">
 Customize the label for the key header.
 
 #### Default
@@ -25,9 +25,9 @@ Customize the label for the key header.
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `value_label`
+<Option name="`value_label`">
 Customize the label for the value header.
 
 #### Default
@@ -37,9 +37,9 @@ Customize the label for the value header.
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `action_text`
+<Option name="`action_text`">
 Customize the label for the add row button tooltip.
 
 #### Default
@@ -49,9 +49,9 @@ Customize the label for the add row button tooltip.
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `delete_text`
+<Option name="`delete_text`">
 Customize the label for the delete row button tooltip.
 
 #### Default
@@ -61,37 +61,37 @@ Customize the label for the delete row button tooltip.
 #### Possible values
 
 Any string value.
-:::
+</Option>
 
-:::option `disabled`
+<Option name="`disabled`">
 Toggle on/off the ability to disable editing keys, editing values, adding rows, and deleting rows for that field.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `disable_editing_keys`
+<Option name="`disable_editing_keys`">
 Toggle on/off the ability to edit the keys for that field. Turning this off will allow the user to customize only the value fields.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `disable_editing_values`
+<Option name="`disable_editing_values`">
 Toggle on/off the ability to edit the values for that field. Turning this off will allow the user to customize only the key fields.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `disable_adding_rows`
+<Option name="`disable_adding_rows`">
 Toggle on/off the ability to add new rows.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `disable_deleting_rows`
+<Option name="`disable_deleting_rows`">
 Toggle on/off the ability to delete rows from that field. Turning this on will prevent the user from deleting existing rows.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
 ## Customizing the labels
 

--- a/docs/3.0/fields/location.md
+++ b/docs/3.0/fields/location.md
@@ -29,7 +29,7 @@ On the <Show /> view you'll get in interactive map and on the edit you'll get on
 
 ## Options
 
-:::option `stored_as`
+<Option name="`stored_as`">
 
 It's customary to have the coordinates in two distinct database columns, one named `latitude` and another `longitude`.
 
@@ -52,3 +52,4 @@ By using this notation, Avo will grab the `latitude` and `longitude` from those 
 This will also render the <Edit /> view with two separate fields to edit the coordinates.
 
 <Image src="/assets/img/fields/location-edit.png" width="2564" height="532" alt="Location field" />
+</Option>

--- a/docs/3.0/fields/markdown.md
+++ b/docs/3.0/fields/markdown.md
@@ -19,14 +19,14 @@ field :description, as: :markdown
 
 ## Options
 
-:::option `always_show`
+<Option name="`always_show`">
 
 By default, the content of the `Markdown` field is not visible on the `Show` view, instead, it's hidden under a `Show Content` link that, when clicked, displays the content. You can set Markdown to always display the content by setting `always_show` to `true`.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `height`
+<Option name="`height`">
 Sets the value of the editor
 
 #### Default
@@ -37,9 +37,9 @@ Sets the value of the editor
 #### Possible values
 
 `auto` or any number in pixels.
-:::
+</Option>
 
-:::option `spell_checker`
+<Option name="`spell_checker`">
 Toggles the editor's spell checker option.
 
 ```ruby
@@ -47,6 +47,6 @@ field :description, as: :markdown, spell_checker: true
 ```
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
 <!-- ## Enable spell checker -->

--- a/docs/3.0/fields/money.md
+++ b/docs/3.0/fields/money.md
@@ -49,7 +49,7 @@ gem "money-rails", "~> 1.12"
 
 ## Options
 
-:::option `currencies`
+<Option name="`currencies`">
 
 The `currencies` option controls which currencies will be visible on the dropdown.
 
@@ -69,4 +69,4 @@ By default it's going to be an empty array.
 Add an array of currencies by the ISO code.
 
 `%w[EUR USD RON PEN]`
-:::
+</Option>

--- a/docs/3.0/fields/number.md
+++ b/docs/3.0/fields/number.md
@@ -13,7 +13,7 @@ field :age, as: :number
 
 ## Options
 
-:::option `min`
+<Option name="`min`">
 Set the `min` attribute.
 
 #### Default
@@ -23,9 +23,9 @@ Set the `min` attribute.
 #### Possible values
 
 Any number.
-:::
+</Option>
 
-:::option `max`
+<Option name="`max`">
 Set the `max` attribute.
 
 #### Default
@@ -35,9 +35,9 @@ Set the `max` attribute.
 #### Possible values
 
 Any number.
-:::
+</Option>
 
-:::option `step`
+<Option name="`step`">
 Set the `step` attribute.
 
 #### Default
@@ -47,7 +47,7 @@ Set the `step` attribute.
 #### Possible values
 
 Any number.
-:::
+</Option>
 
 ## Examples
 

--- a/docs/3.0/fields/progress_bar.md
+++ b/docs/3.0/fields/progress_bar.md
@@ -14,7 +14,7 @@ field :progress, as: :progress_bar
 
 ## Options
 
-:::option `max`
+<Option name="`max`">
 Sets the maximum value of the progress bar.
 
 #### Default
@@ -24,9 +24,9 @@ Sets the maximum value of the progress bar.
 #### Possible values
 
 Any number.
-:::
+</Option>
 
-:::option `step`
+<Option name="`step`">
 Sets the step in which the user can move the slider on the `Edit` and `New` views.
 
 #### Default
@@ -36,15 +36,15 @@ Sets the step in which the user can move the slider on the `Edit` and `New` view
 #### Possible values
 
 Any number.
-:::
+</Option>
 
-:::option `display_value`
+<Option name="`display_value`">
 Choose if the value is displayed on the `Edit` and `New` views above the slider.
 
 <!-- @include: ./../common/default_boolean_true.md-->
-:::
+</Option>
 
-:::option `value_suffix`
+<Option name="`value_suffix`">
 Set a string value to be displayed after the value above the progress bar.
 
 #### Default
@@ -54,7 +54,7 @@ Set a string value to be displayed after the value above the progress bar.
 #### Possible values
 
 `%` or any other string.
-:::
+</Option>
 
 ## Examples
 

--- a/docs/3.0/fields/record_link.md
+++ b/docs/3.0/fields/record_link.md
@@ -51,7 +51,7 @@ end
 
 Besides some of the [default options](./../field-options.html), there are a few custom ones.
 
-:::option `target`
+<Option name="`target`">
 In case you want to set the target to `_blank`.
 
 #### Default value
@@ -67,9 +67,9 @@ In case you want to set the target to `_blank`.
 ```ruby
 field :post, as: :record_link, target: :blank
 ```
-:::
+</Option>
 
-:::option `use_resource`
+<Option name="`use_resource`">
 
 Because you only give it an instance of a record, Avo will try to guess which resource it should use to display the title of the record and how to compute it's link.
 With more advanced configurations (when you have [multiple resources for the same model](./../resources.html#use-multiple-resources-for-the-same-model)) that resource might not be the one that you wish for.
@@ -93,9 +93,9 @@ field :admin, as: :record_link, use_resource: "AdminUser"
 
 field :thumbnail, as: :record_link, use_resource: "Avo::Resources::TinyPhoto"
 ```
-:::
+</Option>
 
-:::option `add_via_params`
+<Option name="`add_via_params`">
 
 In other places where Avo generates a link to a record like in the [`belongs_to` field](./../associations/belongs_to.html), Avo adds `via` params to the URL so it knows how to generate the back button link.
 That URL can also be passed on to other team mates and everyone can have the same navigation experience.
@@ -121,7 +121,7 @@ field :post, as: :record_link, add_via_params: true
 # https://example.com/avo/resources/projects/40
 field :post, as: :record_link, add_via_params: false
 ```
-:::
+</Option>
 
 ## Using computed values
 

--- a/docs/3.0/fields/select.md
+++ b/docs/3.0/fields/select.md
@@ -13,7 +13,7 @@ field :type, as: :select, options: { 'Large container': :large, 'Medium containe
 
 ## Options
 
-:::option `options`
+<Option name="`options`">
 A `Hash` representing the options that should be displayed in the select. The keys represent the labels, and the values represent the value stored in the database.
 
 The options get cast as `ActiveSupport::HashWithIndifferentAccess` objects if they are a `Hash`.
@@ -25,9 +25,9 @@ The options get cast as `ActiveSupport::HashWithIndifferentAccess` objects if th
 #### Possible values
 
 `{ 'Large container': :large, 'Medium container': :medium, 'Tiny container': :tiny }` or any other `Hash`.
-:::
+</Option>
 
-:::option `enum`
+<Option name="`enum`">
 Set the select options as an Active Record [enum](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html). You may use `options` or `enum`, not both.
 
 ```ruby{3,10}
@@ -53,9 +53,9 @@ end
 #### Possible values
 
 `Post::statuses` or any other `enum` stored on a model.
-:::
+</Option>
 
-:::option `display_value`
+<Option name="`display_value`">
 You may want to display the values from the database and not the labels of the options. You may change that by setting `display_value` to `true`.
 
 ```ruby{5}
@@ -68,9 +68,9 @@ end
 ```
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `include_blank`
+<Option name="`include_blank`">
 ## Include blank
 
 The `Select` field also has the `include_blank` option. That can have three values.
@@ -97,7 +97,7 @@ end
 #### Possible values
 
 `nil`, `true`, `false`, or a string to be used as the first option.
-:::
+</Option>
 
 ## Computed options
 

--- a/docs/3.0/fields/status.md
+++ b/docs/3.0/fields/status.md
@@ -21,7 +21,7 @@ field :progress,
 
 ## Options
 
-:::option `failed_when`
+<Option name="`failed_when`">
 Set the values for when the status is `failed`.
 
 #### Default value
@@ -31,9 +31,9 @@ Set the values for when the status is `failed`.
 #### Possible values
 
 `[:closed, :rejected, :failed]` or an array with strings or symbols that indicate the `failed` state.
-:::
+</Option>
 
-:::option `loading_when`
+<Option name="`loading_when`">
 Set the values for when the status is `loading`.
 
 #### Default value
@@ -43,9 +43,9 @@ Set the values for when the status is `loading`.
 #### Possible values
 
 `[:loading, :running, :waiting, "in progress"]` or an array with strings or symbols that indicate the `loading` state.
-:::
+</Option>
 
-:::option `success_when`
+<Option name="`success_when`">
 Set the values for when the status is `success`.
 
 #### Default value
@@ -55,9 +55,9 @@ Set the values for when the status is `success`.
 #### Possible values
 
 `[:done, :success, :deployed, "ok"]` or an array with strings or symbols that indicate the `success` state.
-:::
+</Option>
 
-:::option `neutral_when`
+<Option name="`neutral_when`">
 Set the values for when the status is `neutral`.
 
 #### Default value
@@ -67,6 +67,6 @@ Set the values for when the status is `neutral`.
 #### Possible values
 
 `[:holding, "waiting"]` or an array with strings or symbols that indicate a `neutral` state.
-:::
+</Option>
 
 

--- a/docs/3.0/fields/tags.md
+++ b/docs/3.0/fields/tags.md
@@ -16,7 +16,7 @@ field :skills, as: :tags
 
 ## Options
 
-:::option `suggestions`
+<Option name="`suggestions`">
 
 You can give suggestions to your users to pick from which will be displayed to the user as a dropdown under the field.
 
@@ -74,7 +74,7 @@ class Post < ApplicationRecord
 end
 ```
 
-:::
+</Option>
 
 <Option name="`disallowed`">
 
@@ -115,7 +115,7 @@ field :skills,
 
 </Option>
 
-:::option `suggestions_max_items`
+<Option name="`suggestions_max_items`">
 Set of suggestions that can be displayed at once. The excessive items will be hidden and the user will have to narrow down the query to see them.
 
 ```ruby{4}
@@ -134,8 +134,9 @@ field :skills,
 #### Possible values
 
 Integers
+</Option>
 
-:::option `close_on_select`
+<Option name="`close_on_select`">
 Set whether the `suggestions` dropdown should close after the user makes a selection.
 
 ```ruby{4}
@@ -148,9 +149,9 @@ field :items,
 <Image src="/assets/img/fields/tags-field/close_on_select.gif" width="786" height="436" alt="Avo tags field" />
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `acts_as_taggable_on`
+<Option name="`acts_as_taggable_on`">
 Set the field the `acts_as_taggable_on` is set.
 
 #### Default
@@ -160,9 +161,9 @@ Set the field the `acts_as_taggable_on` is set.
 #### Possible values
 
 Any string or symbol you have configured on your corresponding model.
-:::
+</Option>
 
-:::option `delimiters`
+<Option name="`delimiters`">
 
 Set the characters that will cut off the content into tags when the user inputs the tags.
 
@@ -184,10 +185,10 @@ field :skills,
 
 Valid values are comma `,` and space ` `.
 
-:::
+</Option>
 
 
-:::option `mode`
+<Option name="`mode`">
 
 By default, the tags field produces an array of items (ex: categories for posts), but in some scenarios you might want it to produce a single value (ex: dynamically search for users and select just one). Use `mode: :select` to make the field produce a single value as opposed to an array of values.
 
@@ -207,7 +208,7 @@ Valid values are `nil` for array values and `select` for a single value.
 
 <Image src="/assets/img/fields/tags-field/mode-select.gif" width="800" height="666" alt="" />
 
-:::
+</Option>
 
 <Option name="`fetch_values_from`">
 
@@ -269,6 +270,7 @@ if defined? ::Avo
   end
 end
 ```
+:::
 
 :::info
 When using the `fetch_labels_from` pattern, on the <Show /> and <Index /> views you will see the `id` of those options instead of the label.
@@ -279,9 +281,10 @@ To mitigate that use the `fetch_labels` option.
 
 </Option>
 
-:::option `fetch_labels`
+<Option name="`fetch_labels`">
+
 :::warning
-Deprecated since <Version version="3.10"/> in favor of [`format_using`](tags#format_using)
+Deprecated since <Version version="3.10" /> in favor of [`format_using`](tags#format_using)
 :::
 
 The `fetch_labels` option allows you to pass an array of custom strings to be displayed on the tags field. This option is useful when Avo is displaying a bunch of IDs and you want to show some custom label from that ID's record.
@@ -306,8 +309,9 @@ Avo's default behavior on tags
 #### Possible values
 
 - Array of strings
+</Option>
 
-:::option `format_using`
+<Option name="`format_using`">
 :::info
 Since <Version version="3.10" />
 :::
@@ -340,6 +344,7 @@ Avo's default behavior on tags
 
 - Array of strings, notice that this will replace the DB values
 - Array of hashes with `value` and `label` keys. WIll show the `label` and store the `value`
+</Option>
 
 ## PostgreSQL array fields
 

--- a/docs/3.0/fields/text.md
+++ b/docs/3.0/fields/text.md
@@ -12,7 +12,7 @@ field :title, as: :text
 ```
 ## Options
 
-:::option `as_html`
+<Option name="`as_html`">
 Displays the value as HTML on the `Index` and `Show` views. Useful when you need to link to another record.
 
 ```ruby
@@ -22,10 +22,10 @@ end
 ```
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
 
-:::option `protocol`
+<Option name="`protocol`">
 Render the value with a protocol prefix on the `Index` and `Show` views. So, for example, you can make a text field a `mailto` link very quickly.
 
 ```ruby{3}
@@ -43,7 +43,7 @@ field :email,
 #### Possible values
 
 `mailto`, `tel`, or any other string value you need to pass to it.
-:::
+</Option>
 
 <!-- @include: ./../common/link_to_record_common.md-->
 

--- a/docs/3.0/fields/textarea.md
+++ b/docs/3.0/fields/textarea.md
@@ -14,7 +14,7 @@ field :body, as: :textarea
 ## Options
 
 
-:::option `rows`
+<Option name="`rows`">
 Set the number of rows visible in the `Edit` and `New` views.
 
 ```ruby
@@ -28,4 +28,4 @@ field :body, as: :textarea, rows: 5
 #### Possible values
 
 Any integer.
-:::
+</Option>

--- a/docs/3.0/fields/time.md
+++ b/docs/3.0/fields/time.md
@@ -22,7 +22,7 @@ field :starting_at,
 ```
 
 
-:::option `format`
+<Option name="`format`">
 
 Format the date shown to the user on the `Index` and `Show` views.
 
@@ -33,9 +33,9 @@ Format the date shown to the user on the `Index` and `Show` views.
 #### Possible values
 
 Use [`luxon`](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) formatting tokens.
-:::
+</Option>
 
-:::option `picker_format`
+<Option name="`picker_format`">
 Format the date shown to the user on the `Edit` and `New` views.
 
 #### Default
@@ -45,9 +45,9 @@ Format the date shown to the user on the `Edit` and `New` views.
 #### Possible values
 
 Use [`flatpickr`](https://flatpickr.js.org/formatting) formatting tokens.
-:::
+</Option>
 
-:::option `picker_options`;
+<Option name="`picker_options`;">
 Passes the options here to [flatpickr](https://flatpickr.js.org/).
 
 #### Default
@@ -62,4 +62,4 @@ Use [`flatpickr`](https://flatpickr.js.org/options) options.
 These options may override other options like `picker_options`.
 :::
 
-::::
+</Option>

--- a/docs/3.0/fields/trix.md
+++ b/docs/3.0/fields/trix.md
@@ -19,37 +19,37 @@ Trix field is hidden from the `Index` view.
 
 ## Options
 
-:::option `always_show`
+<Option name="`always_show`">
 By default, the content of the `Trix` field is not visible on the `Show` view; instead, it's hidden under a `Show Content` link that, when clicked, displays the content. You can set Markdown to display the content by setting `always_show` to `true`.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `attachments_disabled`
+<Option name="`attachments_disabled`">
 Hides the attachments button from the Trix toolbar.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `hide_attachment_filename`
+<Option name="`hide_attachment_filename`">
 Hides the attachment's name from the upload output in the field value.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `hide_attachment_filesize`
+<Option name="`hide_attachment_filesize`">
 Hides the attachment size from the upload output in the field value.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `hide_attachment_url`
+<Option name="`hide_attachment_url`">
 Hides the attachment URL from the upload output in the field value.
 
 <!-- @include: ./../common/default_boolean_false.md-->
-:::
+</Option>
 
-:::option `attachment_key`
+<Option name="`attachment_key`">
 Enables file attachments.
 
 #### Default
@@ -59,7 +59,7 @@ Enables file attachments.
 #### Possible values
 
 `nil`, or a symbol representing the `has_many_attachments` key on the model.
-:::
+</Option>
 
 
 ## File attachments

--- a/docs/3.0/gem-server-authentication.md
+++ b/docs/3.0/gem-server-authentication.md
@@ -50,25 +50,25 @@ Now you are ready to add Avo to your `Gemfile`.
 
 Now you can run `bundle install` and `bundler` will pick it up and use it to authenticate on the server.
 
-:::option Heroku
+<Option name="Heroku">
 
 If you're using heroku, you can set the environment variable using the following command. This way `bundler` will use it when authenticating to `packager.dev`.
 
 ```bash
 heroku config:set BUNDLE_PACKAGER__DEV=xxx
 ```
-:::
+</Option>
 
-:::option Hatchbox
+<Option name="Hatchbox">
 
 If you're using Hatchbox, you can set the environment variable in your apps "Environment" tab. This way `bundler` will use it when authenticating to `packager.dev`.
 
 ```yaml
 BUNDLE_PACKAGER__DEV: xxx
 ```
-:::
+</Option>
 
-:::option GitHub Actions
+<Option name="GitHub Actions">
 
 You might need to install Avo's paid gems in you GitHub Actions pipeline. There are two steps you need to take in order to enable that.
 
@@ -101,9 +101,9 @@ jobs:
     steps:
       # Testing and deployment steps
 ```
-:::
+</Option>
 
-:::option Docker and docker compose
+<Option name="Docker and docker compose">
 
 You can build with docker by passing a build argument from your environment.
 
@@ -140,14 +140,14 @@ docker build --build-arg BUNDLE_PACKAGER__DEV=$BUNDLE_PACKAGER__DEV
 ```bash
 docker compose build --build-arg BUNDLE_PACKAGER__DEV=xxx
 ```
-:::
+</Option>
 
 ## FAQ
 
 Frequently asked questions:
 
-:::option `Forbidden 403`
+<Option name="`Forbidden 403`">
 If you're seeing this error `Retrying download gem from https://packager.dev/avo-hq/ due to error (1/4): Gem::RemoteFetcher::FetchError bad response Forbidden 403`, this probably means that bundler does not have access to the `BUNDLE_PACKAGER__DEV` environment variable.
 
 Please read the guides above on how to set that on your development machine and in deployment scenarios.
-:::
+</Option>

--- a/docs/3.0/map-view.md
+++ b/docs/3.0/map-view.md
@@ -39,23 +39,23 @@ end
 You need to add the `mapkick-rb` (not `mapkick`) gem to your `Gemfile` and have the `MAPBOX_ACCESS_TOKEN` environment variable with a valid [Mapbox](https://account.mapbox.com/auth/signup/) key.
 :::
 
-:::option `mapkick_options`
+<Option name="`mapkick_options`">
 The options you pass here are forwarded to the [`mapkick` gem](https://github.com/ankane/mapkick).
-:::
+</Option>
 
-:::option `record_marker`
+<Option name="`record_marker`">
 This block is being applied to all the records present in the current query to fetch the coordinates of off the record.
 
 You may use this block to fetch the coordinates from other places (API calls, cache queries, etc.) rather than the database.
 
 This block has to return a hash compatible with the [`PointMap` items](https://github.com/ankane/mapkick#point-map). Has to have `latitude` and `longitude` and optionally `tooltip`, `label`, or `color`.
-:::
+</Option>
 
-:::option `table`
+<Option name="`table`">
 This is the configuration for the adjacent table. You can set the visibility to `true` or `false`, and set the position of the table `:top`, `:right`, `:bottom`, or `:left`.
-:::
+</Option>
 
-:::option `extra_markers`
+<Option name="`extra_markers`">
 Available since version <Version version="3.10.3" />
 
 Allow to define extra markers. The `extra_markers` block is executed in the [`ExecutionContext`](./execution-context) and should return an array of hashes.
@@ -80,7 +80,7 @@ self.map_view = {
 }
 ```
 <Image src="/assets/img/extra-markers.png" width="3240" height="1970" alt="Map extra markers" />
-:::
+</Option>
 
 ## Make it the default view
 

--- a/docs/3.0/menu-editor.md
+++ b/docs/3.0/menu-editor.md
@@ -89,7 +89,7 @@ end
 
 A few menu item types are supported `link_to`, `section`, `group`, `resource`, and `dashboard`. There are a few helpers too, like `all_resources`, `all_dashboards`, and `all_tools`.
 
-:::option `link_to`
+<Option name="`link_to`">
 
 `link_to` is the menu item that the user will probably interact with the most. It will generate a link on your menu. You can specify the `name`, `path` , and `target`.
 
@@ -100,9 +100,9 @@ link_to "Google", path: "https://google.com", target: :_blank
 <Image src="/assets/img/menu-editor/external-link.jpg" width="254" height="155" alt="Avo menu editor" />
 
 When you add the `target: :_blank` option, a tiny external link icon will be displayed.
-:::
+</Option>
 
-:::option `render`
+<Option name="`render`">
 The `render` method will render renderable objects like partials or View Components.
 
 You can even pass `locals` to partials.
@@ -113,9 +113,9 @@ render "avo/sidebar/items/custom_tool"
 render "avo/sidebar/items/custom_tool", locals: { something: :here }
 render Super::Dooper::Component.new(something: :here)
 ```
-:::
+</Option>
 
-:::option `resource`
+<Option name="`resource`">
 
 To make it a bit easier, you can use `resource` to quickly generate a link to one of your resources. For example, you can pass a short symbol name `:user` or the full name `Avo::Resources::User`.
 
@@ -143,9 +143,9 @@ resource :users, params: -> do
 end
 ```
 
-:::
+</Option>
 
-:::option `dashboard`
+<Option name="`dashboard`">
 
 Similar to `resource`, this is a helper to make it easier to reference a dashboard. You pass in the `id` or the `name` of the dashboard.
 
@@ -162,9 +162,9 @@ You can also change the label for the `dashboard` items to something else.
 dashboard :dashy, label: "Dashy Dashboard"
 ```
 
-:::
+</Option>
 
-:::option `section`
+<Option name="`section`">
 
 Sections are the big categories in which you can group your menu items. They take `name` and `icon` options.
 
@@ -177,9 +177,9 @@ end
 
 <Image src="/assets/img/menu-editor/section.jpg" width="255" height="207" alt="Avo menu editor" />
 
-:::
+</Option>
 
-:::option `group`
+<Option name="`group`">
 
 Groups are smaller categories where you can bring together your items.
 
@@ -192,9 +192,9 @@ end
 ```
 
 <Image src="/assets/img/menu-editor/group.jpg" width="252" height="205" alt="Avo menu editor" />
-:::
+</Option>
 
-:::option `all_resources`
+<Option name="`all_resources`">
 Renders all resources.
 
 ```ruby
@@ -205,9 +205,9 @@ section "App", icon: "heroicons/outline/beaker" do
 end
 ```
 
-:::
+</Option>
 
-:::option `all_dashboards`
+<Option name="`all_dashboards`">
 Renders all dashboards.
 
 ```ruby
@@ -218,9 +218,9 @@ section "App", icon: "heroicons/outline/beaker" do
 end
 ```
 
-:::
+</Option>
 
-:::option `all_tools`
+<Option name="`all_tools`">
 Renders all tools.
 
 ```ruby
@@ -231,7 +231,7 @@ section "App", icon: "heroicons/outline/beaker" do
 end
 ```
 
-:::
+</Option>
 
 ### `all_` helpers
 

--- a/docs/3.0/native-components/avo-panel-component.md
+++ b/docs/3.0/native-components/avo-panel-component.md
@@ -36,65 +36,65 @@ All options are optional. You may render a panel without options.
 <% end %>
 ```
 
-:::option `name`
+<Option name="`name`">
 The name of the panel. It's displayed on the top under the breadcrumbs.
 
 #### Type
 `String`
 
 <Image src="/assets/img/native-components/avo-panel-component/name.jpg" width="773" height="411" alt="" />
-:::
+</Option>
 
-:::option `description`
+<Option name="`description`">
 Small text under the name that speaks a bit about what the panel does.
 
 #### Type
 `String`
 
 <Image src="/assets/img/native-components/avo-panel-component/description.jpg" width="773" height="533" alt="" />
-:::
+</Option>
 
-:::option `classes`
+<Option name="`classes`">
 A list of classes that should be applied to the panel container.
 
 #### Type
 `String`
 
 <Image src="/assets/img/native-components/avo-panel-component/classes.jpg" width="773" height="533" alt="" />
-:::
+</Option>
 
-:::option `body_classes`
+<Option name="`body_classes`">
 A list of classes that should be applied to the body of panel.
 
 #### Type
 `String`
 
 <Image src="/assets/img/native-components/avo-panel-component/body_classes.jpg" width="773" height="533" alt="" />
-:::
+</Option>
 
-:::option `data`
+<Option name="`data`">
 A hash of data attributes to be forwarded to the panel container.
 
 #### Type
 `Hash`
 
 <Image src="/assets/img/native-components/avo-panel-component/classes.jpg" width="773" height="533" alt="" />
-:::
+</Option>
 
-:::option `display_breadcrumbs`
+<Option name="`display_breadcrumbs`">
 Toggles the breadcrumbs visibility. You can't customize the breadcrumbs yet.
 
 #### Type
 `Boolean`
 
 <Image src="/assets/img/native-components/avo-panel-component/display_breadcrumbs.jpg" width="773" height="720" alt="" />
-:::
+</Option>
 
 ## Slots
 
 The component has a few slots where you customize the content in certain areas.
 
-:::option `tools`
+<Option name="`tools`">
 We created this slot as a place to put resource controls like the back, edit, delete, and detach buttons.
 This slot will collapse under the title and description when the screen resolution falls under `1024px`.
 
@@ -111,9 +111,9 @@ The section is automatically aligned to the right using `justify-end` class.
 ```
 
 <Image src="/assets/img/native-components/avo-panel-component/tools-slot.jpg" width="1014" height="226" alt="" />
-:::
+</Option>
 
-:::option `body`
+<Option name="`body`">
 This is one of the main slots of the component where the bulk of the content is displayed.
 
 ```erb{2-4}
@@ -125,9 +125,9 @@ This is one of the main slots of the component where the bulk of the content is 
 ```
 
 <Image src="/assets/img/native-components/avo-panel-component/body-slot.jpg" width="773" height="720" alt="" />
-:::
+</Option>
 
-:::option `bare_content`
+<Option name="`bare_content`">
 Used when displaying the [Grid view](./../grid-view), it displays the data flush in the container and with no background.
 
 ```erb{2-4}
@@ -139,9 +139,9 @@ Used when displaying the [Grid view](./../grid-view), it displays the data flush
 ```
 
 <Image src="/assets/img/native-components/avo-panel-component/grid-view.jpg" width="1312" height="1096" alt="" />
-:::
+</Option>
 
-:::option `footer_tools`
+<Option name="`footer_tools`">
 This is pretty much the same slot as `tools` but rendered under the `body` or `bare_content` slots.
 
 ```erb{2-4}
@@ -153,9 +153,9 @@ This is pretty much the same slot as `tools` but rendered under the `body` or `b
 ```
 
 <Image src="/assets/img/native-components/avo-panel-component/footer-controls.jpg" width="1013" height="295" alt="" />
-:::
+</Option>
 
-:::option `footer`
+<Option name="`footer`">
 The lowest available area at the end of the component.
 
 ```erb{2-4}
@@ -165,9 +165,9 @@ The lowest available area at the end of the component.
   <% end %>
 <% end %>
 ```
-:::
+</Option>
 
-:::option `sidebar`
+<Option name="`sidebar`">
 The sidebar will conveniently show things in a smaller area on the right of the `body`.
 
 ```erb{2-4}
@@ -178,4 +178,4 @@ The sidebar will conveniently show things in a smaller area on the right of the 
 <% end %>
 ```
 <Image src="/assets/img/native-components/avo-panel-component/sidebar.png" width="2032" height="1294" alt="" />
-:::
+</Option>

--- a/docs/3.0/resource-panels.md
+++ b/docs/3.0/resource-panels.md
@@ -156,7 +156,7 @@ end
 
 <Image src="/assets/img/tabs-and-panels/index-view.png" width="1024" height="724" alt="Index view" />
 
-:::option `visible`
+<Option name="`visible`">
 <VersionReq version="3.10.7" />
 The `visible` option allows you to dynamically control the visibility of a panel and all its children based on certain conditions.
 
@@ -169,4 +169,4 @@ panel name: "User information", visible: -> { resource.record.enabled? } do
   field :last_name, as: :text
 end
 ```
-:::
+</Option>

--- a/docs/3.0/resource-sidebar.md
+++ b/docs/3.0/resource-sidebar.md
@@ -37,7 +37,7 @@ end
 
 The fields will be stacked in a similar way in a narrower area on the side of the main panel. You may notice that inside each field, the tabel and value zones are also stacked one on top of the other to allow for a larger area to display the field value.
 
-:::option panel_wrapper
+<Option name="panel_wrapper">
 The `panel_wrapper` it's helpful when you want to render a custom tool inside a sidebar and you don't want to apply the `white_panel_classes` to it
 
 ```ruby
@@ -45,4 +45,4 @@ sidebar panel_wrapper: false do
   tool Avo::ResourceTools::SidebarTool
 end
 ```
-:::
+</Option>

--- a/docs/3.0/resources.md
+++ b/docs/3.0/resources.md
@@ -407,8 +407,9 @@ end
 ## Resource Options
 
 Resources have a few options available for customization.
+```
 
-:::option `self.title`
+<Option name="`self.title`">
 
 Each Avo resource will try to figure out what the title of a record is. It will try the following attributes in order `name`, `title`, `label`, and fallback to the `id`.
 
@@ -450,9 +451,9 @@ class Avo::Resources::Comment < Avo::BaseResource
   }
 end
 ```
-:::
+</Option>
 
-:::option `self.description`
+<Option name="`self.description`">
 
 You might want to display information about the current resource to your users. Then, using the `description` class attribute, you can add some text to the `Index`, `Show`, `Edit`, and `New` views.
 
@@ -491,9 +492,9 @@ class Avo::Resources::User < Avo::BaseResource
   end
 end
 ```
-:::
+</Option>
 
-:::option `self.includes`
+<Option name="`self.includes`">
 
 If you regularly need access to a resource's associations, you can tell Avo to eager load those associations on the `Index` view using `includes`.
 
@@ -510,9 +511,9 @@ end
 
 We know, the array notation looks weird, but it works.
 
-:::
+</Option>
 
-:::option `default_view_type`
+<Option name="`default_view_type`">
 
 On <Index />, the most common view type is `:table`, but you might have some data that you want to display in a `:grid` or `:map`. You can change that by setting `default_view_type` to `:grid` and by adding the `grid` block.
 
@@ -538,9 +539,9 @@ class Avo::Resources::Post < Avo::BaseResource
 end
 ```
 
-:::
+</Option>
 
-:::option `self.model_class`
+<Option name="`self.model_class`">
 
 For some resources you might have a model that is namespaced, or you might have a secondary resource for a model. For that scenario, you can use the `self.model_class` option to tell Avo which model to reference in that resource.
 
@@ -554,9 +555,9 @@ class Avo::Resources::DelayedJob < Avo::BaseResource
 end
 ```
 
-:::
+</Option>
 
-:::option `self.devise_password_optional`
+<Option name="`self.devise_password_optional`">
 
 If you use `devise` and update your user models (usually `User`) without passing a password, you will get a validation error. You can use `devise_password_optional` to stop receiving that error. It will [strip out](https://stackoverflow.com/questions/5113248/devise-update-user-without-password/11676957#11676957) the `password` key from `params`.
 
@@ -570,9 +571,9 @@ end
 
 - [Password field](./fields/password)
 
-:::
+</Option>
 
-::::option `self.visible_on_sidebar`
+<Option name="`self.visible_on_sidebar`">
 
 When you get started, the sidebar will be auto-generated for you with all the [dashboards](./dashboards), resources, and [custom tools](./custom-tools).
 However, you may have resources that should not appear on the sidebar, which you can hide using the `visible_on_sidebar` option.
@@ -588,9 +589,9 @@ This option is used in the **auto-generated menu**, not in the [menu editor](./m
 
 You'll have to use your own logic in the [`visible`](./menu-editor#item-visibility) block for that.
 :::
-::::
+</Option>
 
-:::option `config.buttons_on_form_footers`
+<Option name="`config.buttons_on_form_footers`">
 
 If you have a lot of fields on a resource, that form might get pretty tall. So it would be useful to have the `Save` button in the footer of that form.
 
@@ -605,9 +606,9 @@ end
 
 <Image src="/assets/img/resources/buttons_on_footer.png" width="1276" height="594" alt="Buttons on footer" />
 
-:::
+</Option>
 
-:::option `after_create_path`/`after_update_path`
+<Option name="`after_create_path`/`after_update_path`">
 
 For some resources, it might make sense to redirect to something other than the `Show` view. With `after_create_path` and `after_update_path` you can control that.
 
@@ -627,10 +628,10 @@ You can go more granular and customize these paths or response more using contro
  - [`after_create_path`](./controllers#after_create_path)
  - [`after_update_path`](./controllers#after_update_path)
  - [`after_destroy_path`](./controllers#after_destroy_path)
-:::
+</Option>
 
 
-:::option `self.record_selector`
+<Option name="`self.record_selector`">
 
 You might have resources that will never be selected, and you do not need that checkbox to waste your horizontal space.
 
@@ -643,9 +644,9 @@ end
 ```
 
 <Image src="/assets/img/resources/record_selector.png" width="688" height="361" alt="Hide the record selector." />
-:::
+</Option>
 
-:::option `self.link_to_child_resource`
+<Option name="`self.link_to_child_resource`">
 
 Let's take an example. We have a `Person` model and `Sibling` and `Spouse` models that inherit from it using Single Table Inheritance (STI).
 
@@ -656,9 +657,9 @@ class Avo::Resources::Person < Avo::BaseResource
   self.link_to_child_resource = true
 end
 ```
-:::
+</Option>
 
-:::option `self.keep_filters_panel_open`
+<Option name="`self.keep_filters_panel_open`">
 
 <DemoVideo demo-video="https://youtu.be/M2RsNPPFOio?t=374" />
 
@@ -681,9 +682,9 @@ end
 ```
 
 <Image src="/assets/img/filters/keep-filters-panel-open.gif" width="449" height="800" alt="Avo filters" />
-:::
+</Option>
 
-:::option `self.components`
+<Option name="`self.components`">
 By default, for each view we render an component:
 
 `:index` -> `Avo::Views::ResourceIndexComponent`<br>
@@ -703,7 +704,7 @@ self.components = {
 
 A resource configured with the example above will start using the declared components instead the default ones.
 
-:::warning Warning
+:::warning
 The custom view components must ensure that their initializers are configured to receive all the arguments passed during the rendering of a component. You can verify this in our codebase through the following files:
 
 `:index` -> `app/views/avo/base/index.html.erb`<br>
@@ -729,9 +730,9 @@ self.components = {
 ```
 
 This way you can choose the whatever namespace structure you want and you assure that the initializer is accepting the right arguments.
+</Option>
 
-
-:::option `self.index_query`
+<Option name="`self.index_query`">
 
 ### Unscoped queries on `Index`
 
@@ -750,7 +751,7 @@ class Avo::Resources::Project < Avo::BaseResource
   self.index_query = -> { query.unscoped }
 end
 ```
-:::
+</Option>
 
 ## Cards
 
@@ -781,7 +782,7 @@ end
 
 <Image src="/assets/img/cards_on_resource.png" width="2520" height="1258" alt="Alt text" />
 
-:::option `self.pagination`
+<Option name="`self.pagination`">
 This feature is designed for managing pagination. For example on large tables of data sometimes count is inefficient and unnecessary.
 
 By setting `self.pagination[:type]` to `:countless`, you can disable the pagination count on the index page.
@@ -856,9 +857,9 @@ self.pagination = -> do
 end
 ```
 <Image src="/assets/img/resources/pagination/countless_empty_size.png" width="1029" height="62" alt="Countless pagination size empty" />
-:::
+</Option>
 
-:::option `cache_hash`
+<Option name="`cache_hash`">
 
 The `cache_hash` method is used to compute the cache key for each row. The method looks something like this:
 
@@ -910,3 +911,5 @@ class Avo::Resources::User < Avo::BaseResource
 
   # fields, cards and more
 end
+```
+</Option>

--- a/docs/3.0/routing.md
+++ b/docs/3.0/routing.md
@@ -24,7 +24,7 @@ Avo::Engine.routes.draw do
 end
 ```
 
-:::option `Avo.mount_engines` helper
+<Option name="`Avo.mount_engines` helper">
 
 In order to make mounting the engines easier we added the `Avo.mount_engines` helper which returns a block that can be run in any routing context.
 
@@ -36,7 +36,7 @@ Avo::Engine.routes.draw do
   # other routes
 end
 ```
-:::
+</Option>
 
 Sometimes you might have more exotic use-cases so you'd like to customize those paths accordingly.
 

--- a/docs/3.0/scopes.md
+++ b/docs/3.0/scopes.md
@@ -63,7 +63,7 @@ end
 
 The scope classes take a few options.
 
-:::option `name`
+<Option name="`name`">
 This value is going to be displayed on the scopes bar as the name of the scope.
 
 This can be a callable value and it receives the `resource` and `query` objects.
@@ -71,15 +71,15 @@ This can be a callable value and it receives the `resource` and `query` objects.
 The `query` object can be used to compute and display the record count.
 
 Please see [the recipe](./guides/display-scope-record-count.html) on how to enable it.
-:::
+</Option>
 
-:::option `description`
+<Option name="`description`">
 This value is going to be displayed when the user hovers over the scope.
 
 This can be a callable value and it receives the `resource` and `query` objects.
-:::
+</Option>
 
-:::option `scope`
+<Option name="`scope`">
 The scope you return here is going to be applied to the query of records on that page.
 
 You can use a symbol which will indicate the scope on that model or a block which will have the `query` available so you can apply any modifications you need.
@@ -92,8 +92,8 @@ class Avo::Scopes::EvenId < Avo::Advanced::Scopes::BaseScope
   self.visible = -> { true }
 end
 ```
-:::
+</Option>
 
-:::option `visible`
+<Option name="`visible`">
 From this block you can show, hide, and authorize the scope on the resource.
-:::
+</Option>

--- a/docs/3.0/search.md
+++ b/docs/3.0/search.md
@@ -102,7 +102,7 @@ Avo.configure do |config|
 
 ## Configure the search result
 
-:::option `title`
+<Option name="`title`">
 
 By default, the search results will be displayed as text. By default search title will be the [resource title](./resources.html#self_title).
 
@@ -124,9 +124,9 @@ end
 ```
 
 <Image src="/assets/img/search/search_label.jpg" width="1406" height="674" alt="Search label" />
-:::
+</Option>
 
-:::option `description`
+<Option name="`description`">
 <LicenseReq license="pro" />
 
 You might want to show more than just the title in the search result. Avo provides the `card -> description` option to add some more information.
@@ -146,9 +146,9 @@ end
 ```
 
 <Image src="/assets/img/search/search_description.jpg" width="1396" height="754" alt="Search description" />
-:::
+</Option>
 
-:::option `image_url`
+<Option name="`image_url`">
 
 <LicenseReq license="pro" />
 
@@ -169,7 +169,7 @@ class Avo::Resources::Post < Avo::BaseResource
 end
 ```
 
-:::option `image_format`
+</Option>option `image_format`
 
 <LicenseReq license="pro" />
 
@@ -193,7 +193,7 @@ end
 
 <Image src="/assets/img/search/search_avatar.jpg" width="1400" height="794" alt="Search avatar" />
 
-:::option `help`
+<Option name="`help`">
 
 You may improve the results listing header by adding a piece of text highlighting the fields you are looking for or any other instruction for the user. You do that by using the `help` attribute. This attribute takes a string and appends it to the title of the resource.
 
@@ -207,9 +207,9 @@ class Avo::Resources::Post < Avo::BaseResource
   }
 end
 ```
-:::
+</Option>
 
-:::option `result_path`
+<Option name="`result_path`">
 
 By default, when a user clicks on a search result, they will be redirected to that record, but you can change that using the `result_path` option.
 
@@ -221,9 +221,9 @@ class Avo::Resources::City < Avo::BaseResource
   }
 end
 ```
-:::
+</Option>
 
-:::option `hide_on_global`
+<Option name="`hide_on_global`">
 
 You might have a resource that you'd like to be able to perform a search on when on its `Index` page but not have it present in the global search. You can hide it using `hide_on_global: true`.
 
@@ -240,7 +240,7 @@ class Avo::Resources::TeamMembership < Avo::BaseResource
   }
 end
 ```
-:::
+</Option>
 
 ## Resource search
 

--- a/docs/3.0/upgrade.md
+++ b/docs/3.0/upgrade.md
@@ -5,10 +5,10 @@ We'll update this page when we release new Avo 3 versions.
 If you're looking for the Avo 2 to Avo 3 upgrade guide, please visit [the dedicated page](./avo-2-avo-3-upgrade).
 
 ## Upgrade from 3.10.6 to 3.10.7
-:::option Boolean field
+<Option name="Boolean field">
 
 In versions lower than <Version version="3.10.6" />, boolean fields with a `nil` value were represented by a red X, which could be misleading. <VersionReq version="3.10.7" /> when a boolean field has a `nil` value, it is displayed with a dash (`—`) instead of a red X.
-:::
+</Option>
 
 <!-- ## Rails 8 support -->
 
@@ -113,14 +113,14 @@ More on that on this [issue](https://github.com/avo-hq/avo/issues/2844).
 
 ## Upgrade from 3.6.1 to 3.6.2
 
-:::option Cache
+<Option name="Cache">
 From version `3.6.1` to version `3.6.2` table cache logic suffered some changes. Old cached table may break with this change, we recommend to clear cache on production after upgrade (`Rails.cache.clear`).
 
 Versions `3.6.2` / `3.6.3` have some issues around cache, we recommend to upgrade directly to `3.6.4`.
-:::
+</Option>
 
 ## Upgrade from 3.5.4 to 3.5.5
-:::option Record errors
+<Option name="Record errors">
 With version `3.5.5` we introduced a stricter error check. Now when the record has any error attached the save action will fail automatically. This allow you to do things like:
 
 ```ruby
@@ -131,10 +131,10 @@ before_update do
 end
 ```
 
-:::
+</Option>
 
 ## Upgrade from 3.4.2 to 3.4.3
-:::option `turbo` configuration
+<Option name="`turbo` configuration">
 In version `3.4.2` we introduced turbo configuration with `instantclick` option. We decided that `instant_click` is a more appropriate name.
 
 ```ruby
@@ -143,10 +143,10 @@ config.turbo = {
   instant_click: true # [!code ++]
 }
 ```
-:::
+</Option>
 
 ## Upgrade from 3.4.1 to 3.4.2
-:::option Basic Filters URL param changed to `encoded_filters`
+<Option name="Basic Filters URL param changed to `encoded_filters`">
 When we added the [Dynamic Filters](./dynamic-filters) feature, by mistake we introduced a bug where you couldn't use the [Basic](./basic-filters) and [Dynamic Filters](./dynamic-filters) together because they are both using the `filters` URL param.
 
 This is not what we intended.
@@ -166,23 +166,23 @@ If you have hardcoded links where you reference the `filters` param, change that
 These links might be in Tools, Resource Tools, Menu Items, or regular view partials (yes, basically anywhere you might have added them 🫤).
 
 A quick search through your codebase should reveal them.
-:::
+</Option>
 
-:::option Add `active_record_extended` gem to your `Gemfile`
+<Option name="Add `active_record_extended` gem to your `Gemfile`">
 In order to extend Avo's filtering capabilities for arrays and tags fields, we use the [`active_record_extended`](https://github.com/GeorgeKaraszi/ActiveRecordExtended) gem.
 
 This gem uses postgres and was breaking for those who use any other database like `sqlite`.
 
 If you want to keep `Contained in` option on arrays and tags filters you should include the `active_record_extended` gem to your `Gemfile`.
-:::
+</Option>
 
-:::option Multiple action flux
+<Option name="Multiple action flux">
 First iteration of multiple action flux was using `redirect_to` with `turbo_frame: "actions_show"`. With the update to turbo 8 the redirect was giving some troubles and we decided that is time to improve this experience with a proper response type, [`navigate_to_action`](actions.html#navigate_to_action).
 
 If you have a multiple action flux implemented with `redirect_to` you should change it to [`navigate_to_action`](actions.html#navigate_to_action).
-:::
+</Option>
 
-:::option Action `link_arguments` method
+<Option name="Action `link_arguments` method">
 Action `link_arguments` method handles the `arguments` encoding and encryption internally now so you only need to pass the `arguments` as a hash and the returned `path` will already include the encoded arguments.
 
 ```ruby{20,21,22,23,25}
@@ -212,26 +212,26 @@ field :name,
 
   link_to resource.record.name, path, data: data
 end
-:::
+</Option>
 
-:::option `resource.record` or `record` as `nil` on visibility blocks
+<Option name="`resource.record` or `record` as `nil` on visibility blocks">
 You may notice that `resource.record == nil` on some visibility blocks. That happens when evaluating the field visibility to render header columns. On index, there is no record.
 
 This is a consequence of a bug fix where `resource.record` was wrongly storing the last record of the index table.
 
 Check [this discussion](https://github.com/avo-hq/avo/issues/2544) for more details
-:::
+</Option>
 
 ## Upgrade from 3.3.0 to 3.4.0
 
 Ruby 3.0 is end-of-life and we pushed some code that only works with Ruby 3.1.
 
 ## Upgrade from 3.2.2 to 3.3.0
-:::option `may_download_file` deprecated
+<Option name="`may_download_file` deprecated">
 Actions now fully operate with turbo leading to the deprecation of `may_download_file` option. It can be safely removed from all actions.
-:::
+</Option>
 
-:::option Status field `failed_when` and `loading_when` default to and empty array
+<Option name="Status field `failed_when` and `loading_when` default to and empty array">
 We found [some issues](https://github.com/avo-hq/avo/pull/2316) with declaring defaults to `failed_when` and `loading_when` field options so we are now defaulting them to empty arrays.
 
 If you need that behavior back, add it to your fields.
@@ -242,13 +242,13 @@ field :status,
   failed_when: [:failed],
   loading_when: [:waiting, :running]
 ```
-:::
+</Option>
 
-:::option Scopes namespace change
+<Option name="Scopes namespace change">
 Scopes changed namespace from `Avo::Pro::Scopes` to `Avo::Advanced::Scopes`.
-:::
+</Option>
 
-:::option TailwindCSS integration
+<Option name="TailwindCSS integration">
 The symlink generated by `avo:sym_link` task was renamed from `tmp/avo/base.css` to `tmp/avo/avo.base.css`. If your application has the TailwindCSS integration generated before Avo `3.3.0` you should replace `@import '../../../../tmp/avo/base.css';` with `'../../../../tmp/avo/avo.base.css';` in `app/assets/stylesheets/avo/avo.tailwind.css`.
 
 ```css
@@ -257,33 +257,33 @@ The symlink generated by `avo:sym_link` task was renamed from `tmp/avo/base.css`
 @import '../../../../tmp/avo/base.css'; // [!code --]
 @import '../../../../tmp/avo/avo.base.css'; // [!code ++]
 ```
-:::
+</Option>
 
 ## Upgrade from 3.1.3 to 3.1.4
 
-:::option `Avo::Filters::BaseFilter.decode_filters`
+<Option name="`Avo::Filters::BaseFilter.decode_filters`">
 We removed the rescue that would return `{}` on parsing error. This rescue block was occasionally concealing pertinent errors. Ensure that when invoking `Avo::Filters::BaseFilter.decode_filters` the argument is not `nil` and has been encoded using the `Avo::Filters::BaseFilter.encode_filters` method.
-:::
+</Option>
 
 ## Upgrade from 3.0.1.beta24 to 3.0.2
 
-:::option Sidebar should be declared inside a panel
+<Option name="Sidebar should be declared inside a panel">
 We introduced the `main_panel` option and also refactored the way that fields are fetched from the resource, now we allow multiple sidebars per panel but each sidebar should be defined inside a `panel` or `main_panel` block.
 
 We suggest to read [panels](resource-panels) and [sidebars](resource-sidebar) sections for more information and to be aware of the new possibilities.
-:::
+</Option>
 
-:::option Dashboards visibility and authorization
+<Option name="Dashboards visibility and authorization">
 Previously, if the `visible` attribute was set to `false` on dashboards, visiting them was impossible because the controller would trigger a "Not found" error. In cases where `authorize` returned `false`, the controller would block access but still keep the dashboard visible.
 
 This behavior has been enhanced. Now, even if `visible` is set to `false`, the dashboard remains accessible but won't appear in the menu. Additionally, if `authorize` returns `false`, the dashboards are now hidden.
-:::
+</Option>
 
-:::option Actions
+<Option name="Actions">
 We've internally implemented some changes around actions to resolve certain bugs. No action is needed from your end, but if you happen to notice any anomalies in the actions flow, please get in touch with us so we can address them promptly. Thank you.
-:::
+</Option>
 
-:::option Attachments eager load
+<Option name="Attachments eager load">
 
 Attachments are no longer automatically eager loading. If you want to eager load attachments there are at least two ways:
 
@@ -311,11 +311,11 @@ class Avo::Resources::Product < Avo::BaseResource
   end
 ```
 
-:::
+</Option>
 
 ## Upgrade from 3.0.1.beta23 to 3.0.1.beta24
 
-:::option Cards
+<Option name="Cards">
 With the new feature that allow [cards on resources](resources.html#cards)  we've realized that it's no longer logical to retain cards within the `Dashboard` namespace scope. Consequently, each card is now located within the `Avo::Cards` namespace.
 
 ```ruby
@@ -332,24 +332,24 @@ class Avo::Cards::ExampleBarChart < Avo::Cards::ChartkickCard
 # ...
 
 ```
-:::
+</Option>
 
 
 ## Upgrade from 3.0.1.beta22 to 3.0.1.beta23
-:::option Caching
+<Option name="Caching">
 Since there are many available cache stores and we were allowing only few we changed the way of computing the cache store to be used by Avo.
 
 One of our concerns was to maintain the status quo, but if you notice any caching issues there is a new configurable option [`config.cache_store`](cache#custom-selection) that allows you to tell Avo what `cache_store` to use.
 
 Check [cache page](cache) for more details.
-:::
+</Option>
 
 ## Upgrade from 3.0.1.beta8 to 3.0.1.beta9
-:::option Heading as field
+<Option name="Heading as field">
 Heading option changed declaration mode, one of the main reasons for this change is to be able to generate a clear `data-field-id` on the DOM
 
 For more information about `heading` field syntax check [`heading` field's documentation](./fields/heading).
-::: code-group
+:::code-group
 ```ruby [Before]
 heading "personal information"
 heading "contact"
@@ -362,10 +362,11 @@ field :heading, as: :heading, label: "Contact"  # data-field-id == "heading"
 field :dev, as: :heading, as_html: true, label: '<div class="underline uppercase font-bold">DEV</div>'
 ```
 :::
+</Option>
 
-:::option Badge field `secondary` option renamed to `neutral`
+<Option name="Badge field `secondary` option renamed to `neutral`">
 We believe that the term `neutral` better reflects the intended use.
-::: code-group
+:::code-group
 ```ruby {8} [Before]
 field :stage,
   as: :badge,
@@ -390,10 +391,11 @@ field :stage,
   }
 ```
 :::
+</Option>
 
-:::option Rename `link_to_resource` to `link_to_record`
+<Option name="Rename `link_to_resource` to `link_to_record`">
 `link_to_resource` was renamed to `link_to_record`.
-::: code-group
+:::code-group
 ```ruby {3-4} [Before]
 class Avo::Resources::User < Avo::BaseResource
   def fields
@@ -411,11 +413,11 @@ class Avo::Resources::User < Avo::BaseResource
   end
 end
 ```
-:::
+</Option>
 
 ## Upgrade from 3.0.1.beta5 to 3.0.1.beta6
 
-:::option The status field changed behavior
+<Option name="The status field changed behavior">
 Before, for the status you'd set the `failed` and `loading` states and everything else fell under `success`. That felt unnatural. We needed a `neutral` state.
 Now we changed the field so you'll set the `failed`, `loading`, and `success` values and the rest fall under `neutral`.
 
@@ -433,4 +435,4 @@ field :status,
   loading_when: :loading
   success_when: :deployed # specify the success state
 ```
-:::
+</Option>

--- a/docs/3.0/views.md
+++ b/docs/3.0/views.md
@@ -2,34 +2,34 @@
 
 The Avo CRUD feature generates with four main views for each resource.
 
-:::option `Index`
+<Option name="`Index`">
 The page where you see all your resources listed in a table or a [grid](grid-view.html).
 
 <RelatedList>
   <RelatedItem href="./customization.html#click_row_to_view_record">Click row to view record</RelatedItem>
 </RelatedList>
 
-:::
+</Option>
 
-:::option `Show`
+<Option name="`Show`">
 The page where you see one resource in more detail.
-:::
+</Option>
 
-:::option `Edit`
+<Option name="`Edit`">
 The page where you can edit one resource.
-:::
+</Option>
 
-:::option `New`
+<Option name="`New`">
 The page where you can create a new resource.
-:::
+</Option>
 
-:::option `Display`
+<Option name="`Display`">
 `:display` is an alias for the the `Index` and `Show` views where you can display records and their details.
-:::
+</Option>
 
-:::option `Form`
+<Option name="`Form`">
 `:form` is an alias for the `Edit` and `New` views for creating and editing records.
-:::
+</Option>
 
 ## Preview
 

--- a/docs/common/technical-support.md
+++ b/docs/common/technical-support.md
@@ -13,9 +13,6 @@ But, even the best of us get stuck at some point and you might need a nudge in t
 2. [Demo apps](#demo-apps)
 3. [Paid support](#paid-support) -->
 
-<!-- :::tip Help levels
-
-::: -->
 
 ## Open Source Software Support
 
@@ -44,13 +41,14 @@ For users seeking assistance with application-specific issues, we offer a few pa
 2. Advanced hands-on support
 
 For more information about our support plans, please visit [this](https://avohq.io/support) page.
+
 :::
 
 ## Self help
 
 This is how you can help yourself.
 
-:::option 1. The docs
+<Option name="1. The docs">
 
 We work hard to ensure these documentation pages express everything Avo can do and keep them up to date.
 
@@ -69,9 +67,10 @@ We use Algolia DocSearch so you can quickly find what you're looking for.
 We compiled a list of helpful [guides](./../3.0/guides.html) from ourselves and the community and a few [FAQ](./../3.0/faq.html) items for you to check out.
 
 </div>
-:::
 
-::::option 2. GitHub Issues & Discussions
+</Option>
+
+<Option name="2. GitHub Issues & Discussions">
 
 <div class="pl-6">
 
@@ -102,9 +101,10 @@ We prefer GitHub Issues over any other form of communication.
 :::
 
 </div>
-::::
 
-:::option 3. Demo apps
+</Option>
+
+<Option name="3. Demo apps">
 
 These apps have been made to showcase the technical abilities of Avo. You can browse their source-code to uncover many examples of how you can use Avo in many environments and with advanced use-cases.
 
@@ -112,13 +112,14 @@ The [main demo app](https://main.avodemo.com/) is a catch-all all that mimics an
 
 The [ticketing demo app](https://ticketing.avodemo.com/) is an example of how you could build a ticketing support app for your customers completely in Avo.
 It also features websockets integration for live commenting on tickets alongside a custom tool that serves as a "Settings" page.
-:::
+
+</Option>
 
 ## Help from the official team
 
 You sometimes need help from the authors. There are a few ways to do that.
 
-:::option 1. "Thursday is community day"
+<Option name="1. Thursday is community day">
 
 We know that sometimes you just need to ask a quick question and a chat is the best place for that.
 From our experience, few quick questions are actually quick. Most of the times the answer is "it depends", and we need more information about the problem.
@@ -130,9 +131,9 @@ We are lucky that other community members have experience and pitch in from time
 
 On Thursday we'll be present on the Discord server where we can answer your questions.
 
-:::
+</Option>
 
-:::option 2. Paid support
+<Option name="2. Paid support">
 
 <!-- Due to the nature of how time-consuming support is, we can't treat each issue the same or allocate the same amount of time.
 The policy is that if it's something simple that we can figure on the spot we will happily answer. If it's something we can reproduce really quick, we will do it and answer the inquiry. -->
@@ -145,7 +146,7 @@ The paid support chat comes in different flavours.
 
 If you'd like to know more about that, see our standard plans [here](https://avohq.io/support) or reach out to us on [email](mailto:adrian@avohq.io?subject=I'd%20like%20to%20know%20more%20about%20your%20Tech%20Support%20plans&body=Hi%2C%0D%0A%0D%0AMy%20name%20is%20...%2C%20I%20represent%20...%2C%20and%20I'd%20like%20to%20know%20...).
 
-:::
+</Option>
 
 ## Reproduction repository
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ The second section is the `Options` section marked by an `h2` (`##`) paragraph.
 We should pass each option following this pattern:
 
 ```markdown
-:::option `OPTION_NAME_IN_CODE_BLOCK`
+<Option name="`OPTION_NAME_IN_CODE_BLOCK`">
 
 Short description of the feature.
 
@@ -25,7 +25,7 @@ Images here.
 
 Some possible values if they are known (`true`, `false`, `" "` `"on"`, `"off"`, etc.) or a text description about them.
 
-:::option
+</Option>
 ```
 
 After the options, if the field has a lot of options and permutations and you'd like to show more, we can add an `## Examples` block.


### PR DESCRIPTION
Convert from markdown extension to `Option` component.

The markdown extension `:::option` proved to be unreliable and not render things properly resulting in hydration mismatch and content dissapearing.

![CleanShot 2024-07-27 at 01 15 35@2x](https://github.com/user-attachments/assets/3d113322-b0f9-48cd-8746-25c62e536de4)


https://github.com/user-attachments/assets/75cd3a5b-3789-4e0f-90e6-5200977c1d05

