### PR TITLE
Testing Docs: Use `query` in both cases

### DIFF
--- a/docs/3.0/testing.md
+++ b/docs/3.0/testing.md
@@ -42,7 +42,7 @@ end
 ```ruby
 require 'rails_helper'
 
-RSpec.feature ReleaseFish, type: :feature do
+RSpec.feature Avo::Actions::ReleaseFish, type: :feature do
   let(:fish) { create :fish }
   let(:current_user) { create :user }
   let(:resource) { Avo::Resources::User.new.hydrate model: fish }

--- a/docs/3.0/testing.md
+++ b/docs/3.0/testing.md
@@ -54,7 +54,7 @@ RSpec.feature ReleaseFish, type: :feature do
       },
       current_user: current_user,
       resource: resource,
-      records: [fish]
+      query: [fish]
     }
 
     action = described_class.new(resource: resource, user: current_user, view: :edit)


### PR DESCRIPTION
In the action example, the expected keyword is `query`, but in the spec itself, it's `records`. This does not currently work and we had to figure out that we need to use `query` in both cases.

Additionally, we had to use the full namespace so that the spec was runnable.