### PR TITLE
new_session_path delegation for authentication

### DIFF
--- a/docs/3.0/guides/rails-authentication-scaffold.md
+++ b/docs/3.0/guides/rails-authentication-scaffold.md
@@ -38,11 +38,14 @@ Now, here comes the part which might seem unfamiliar but it's actually pretty st
 
 The scaffold adds the `Authentication` concern to your `ApplicationController` which is great. We will add it to Avo's `ApplicationController` and also add the `before_action`, but instead of just appending it wil will prepend it so we can ensure it will be fired as soon as possible in the request lifecycle.
 
-```ruby{4,7}
+Since `require_authentication` runs in the Avo context, it's necessary to delegate the `new_session_path` to the `main_app` to ensure proper routing.
+
+```ruby{4,5,8}
 # app/controllers/avo/application_controller.rb
 module Avo
   class ApplicationController < BaseApplicationController
     include Authentication
+    delegate :new_session_path, to: :main_app
 
     # we are prepending the action to ensure it will be fired very early on in the request lifecycle
     prepend_before_action :require_authentication


### PR DESCRIPTION
Since `require_authentication` runs in the Avo context, it's necessary to delegate the `new_session_path` to the `main_app` to ensure proper routing.

Reported here: https://discord.com/channels/740892036978442260/1326073334982774887

# How to reproduce the issue

1. `rails _8.0.1_ new avo_auth`
2. `bin/rails app:template LOCATION='https://avohq.io/app-template'`
3. `bin/rails generate authentication`
4. `bin/rails db:migrate`
5. Follow https://docs.avohq.io/3.0/guides/rails-authentication-scaffold.html#authentication-using-rails-scaffold
6. `bin/dev`
7. visit http://localhost:3000/avo
8. Notice error:
![image](https://github.com/user-attachments/assets/20063326-689a-4ff0-b3ad-d6dd689ea82a)
9. Insert `delegate :new_session_path, to: :main_app` on `app/controllers/avo/application_controller.rb`
10. visit http://localhost:3000/avo
11. Works as expected.