### PR TITLE
Update actions.md

### DIFF
--- a/docs/3.0/actions.md
+++ b/docs/3.0/actions.md
@@ -551,7 +551,7 @@ You will be prompted by a confirmation modal when you run an action. If you don'
 
 ## Standalone actions
 
-You may need to run actions that are not necessarily tied to a model. Standalone actions help you do just that. Add `self.standalone` to an existing action or generate a new one using the `--standalone` option (`bin/rails generate avo:action global_action --standalone`).
+You may need to run actions that are not necessarily tied to specific records. Standalone actions help you do just that. Add `self.standalone` to an existing action or generate a new one using the `--standalone` option (`bin/rails generate avo:action global_action --standalone`).
 
 ```ruby{3}
 class Avo::Actions::DummyAction < Avo::BaseAction


### PR DESCRIPTION
I think the description of standalone actions could be better. As far as I understand it, default (non-standalone) actions always act on the selected records (in index view) or the current record (in show view). Is that correct?

When I added a non-standalone action and clicked on it in the index view (without first selecting any records), nothing happened. Maybe a popup saying "please select some records first" would be more helpful?